### PR TITLE
Add Keywords to desktop file as recommended

### DIFF
--- a/data/gimagereader.desktop.in
+++ b/data/gimagereader.desktop.in
@@ -11,3 +11,4 @@ Type=Application
 StartupNotify=true
 Categories=Graphics;OCR;
 MimeType=image/bmp;image/jpeg;image/gif;image/png;image/tiff;image/x-bmp;image/x-ico;image/x-png;image/x-pcx;image/x-tga;image/xpm;image/svg+xml;
+Keywords=OCR;optical character recognition;Scanner;tesseract;


### PR DESCRIPTION
It's recommended to have Keywords in the desktop file as Unity, Gnome Shell etc. rely on them for proposing applications to users, see: https://wiki.gnome.org/Initiatives/GnomeGoals/DesktopFileKeywords