### PR TITLE
On ARMEL std::exception_ptr is missing - QT part of the fix.

### DIFF
--- a/qt/src/MainWindow.cc
+++ b/qt/src/MainWindow.cc
@@ -75,6 +75,7 @@ static void signalHandler(int signal)
 	std::raise(signal);
 }
 
+#ifndef __ARMEL__
 static void terminateHandler()
 {
 	std::set_terminate(nullptr);
@@ -92,7 +93,7 @@ static void terminateHandler()
 	}
 	signalHandler(SIGABRT);
 }
-
+#endif
 
 MainWindow* MainWindow::s_instance = nullptr;
 
@@ -103,7 +104,9 @@ MainWindow::MainWindow(const QStringList& files)
 
 	std::signal(SIGSEGV, signalHandler);
 	std::signal(SIGABRT, signalHandler);
+#ifndef __ARMEL__
 	std::set_terminate(terminateHandler);
+#endif
 
 	qRegisterMetaType<MainWindow::State>();
 


### PR DESCRIPTION
ARMEL's CPU default is too old to support std::exception_ptr. As Debian sill builds for ARMEL it fails to build without.