### PR TITLE
[GTK] OutputEditorHOCR: Fix removeCurrentItem

### DIFF
--- a/gtk/src/OutputEditorHOCR.cc
+++ b/gtk/src/OutputEditorHOCR.cc
@@ -929,13 +929,14 @@ void OutputEditorHOCR::updateCurrentItem()
 
 void OutputEditorHOCR::removeCurrentItem()
 {
-	if(m_currentElement) {
+	if(m_currentItem) {
+		g_assert_nonnull(m_currentElement);
 		m_currentElement->get_parent()->remove_child(m_currentElement);
 		Gtk::TreeIter toplevelItem = m_itemStore->get_iter(m_currentPageItem);
 		toplevelItem->set_value(m_itemStoreCols.source, getDocumentXML(m_currentParser->get_document()));
 
 		m_itemStore->erase(m_itemStore->get_iter(m_currentItem));
-		m_currentItem = Gtk::TreePath();
+		// m_currentItem updated by m_itemView->get_selection()->signal_changed()
 	}
 }
 


### PR DESCRIPTION
We shouldn't clear the m_currentItem, because m_itemStore->erase triggers
selection change.

Fixes crash caused by an invalid iterator.

PS: Is there any code style guidelines for contributors for cases like `if(...) {`?  