### PR TITLE
[Qt] OutputEditorHOCR: Don't work with null item

### DIFF
--- a/qt/src/OutputEditorHOCR.cc
+++ b/qt/src/OutputEditorHOCR.cc
@@ -934,6 +934,9 @@ void OutputEditorHOCR::showTreeWidgetContextMenu(const QPoint &point){
 	}
 
 	QTreeWidgetItem* item = ui.treeWidgetItems->itemAt(point);
+	if(!item) {
+		return;
+	}
 	QString itemClass = item->data(0, ClassRole).toString();
 	if(itemClass.isEmpty()) {
 		return;


### PR DESCRIPTION
Fixes crash after clicking on empty area below items.