### PR TITLE
[Gtk] SubstitutionsManager::openList: Keep empty lines in Utils::string_split

### DIFF
--- a/gtk/src/SubstitutionsManager.cc
+++ b/gtk/src/SubstitutionsManager.cc
@@ -100,7 +100,7 @@ void SubstitutionsManager::openList() {
 			if(text.empty()) {
 				continue;
 			}
-			std::vector<Glib::ustring> fields = Utils::string_split(text, '\t');
+			std::vector<Glib::ustring> fields = Utils::string_split(text, '\t', true);
 			if(fields.size() < 2) {
 				errors = true;
 				continue;


### PR DESCRIPTION
Fixes false error message after loading a list that contains empty pairs.

It probably makes sense to set `keedEmpty` to `true` by default to match Qt's behavior.