### PR TITLE
[Qt] Displayer::getImage: Use smooth pixmap transformation

### DIFF
--- a/qt/src/Displayer.cc
+++ b/qt/src/Displayer.cc
@@ -413,6 +413,7 @@ QImage Displayer::getImage(const QRectF& rect) {
 	QImage image(rect.width(), rect.height(), QImage::Format_RGB32);
 	image.fill(Qt::black);
 	QPainter painter(&image);
+	painter.setRenderHint(QPainter::SmoothPixmapTransform);
 	QTransform t;
 	t.translate(-rect.x(), -rect.y());
 	t.rotate(ui.spinBoxRotation->value());


### PR DESCRIPTION
Significantly improves quality of rotated images:
![pic](https://cloud.githubusercontent.com/assets/10910745/19828498/96252768-9dcf-11e6-9794-06f3ab228a3a.png)
