### PR TITLE
Recognize guillemets as quote characters (fixes #177)

### DIFF
--- a/gtk/src/OutputEditorText.cc
+++ b/gtk/src/OutputEditorText.cc
@@ -175,8 +175,8 @@ void OutputEditorText::filterBuffer() {
 			preChars += "\\.\\?!"; // Keep if preceded by end mark (.?!)
 		}
 		if(m_filterKeepIfQuote->get_active()) {
-			preChars += "'\"»«"; // Keep if preceded by quote
-			sucChars += "'\"«»"; // Keep if succeeded by quote
+			preChars += "'\"\u00BB\u00AB"; // Keep if preceded by quote
+			sucChars += "'\"\u00AB\u00BB"; // Keep if succeeded by quote
 		}
 		if(m_filterKeepParagraphs->get_active()) {
 			sucChars += "\\n"; // Keep if succeeded by line break

--- a/gtk/src/OutputEditorText.cc
+++ b/gtk/src/OutputEditorText.cc
@@ -175,8 +175,8 @@ void OutputEditorText::filterBuffer() {
 			preChars += "\\.\\?!"; // Keep if preceded by end mark (.?!)
 		}
 		if(m_filterKeepIfQuote->get_active()) {
-			preChars += "'\""; // Keep if preceded by dot
-			sucChars += "'\""; // Keep if succeeded by dot
+			preChars += "'\"»«"; // Keep if preceded by quote
+			sucChars += "'\"«»"; // Keep if succeeded by quote
 		}
 		if(m_filterKeepParagraphs->get_active()) {
 			sucChars += "\\n"; // Keep if succeeded by line break

--- a/qt/src/OutputEditorText.cc
+++ b/qt/src/OutputEditorText.cc
@@ -136,8 +136,8 @@ void OutputEditorText::filterBuffer() {
 			preChars += "\\.\\?!"; // Keep if preceded by end mark (.?!)
 		}
 		if(ui.actionOutputPostprocKeepQuote->isChecked()) {
-			preChars += "'\""; // Keep if preceded by dot
-			sucChars += "'\""; // Keep if succeeded by dot
+			preChars += "'\"»«"; // Keep if preceded by quote
+			sucChars += "'\"«»"; // Keep if succeeded by quote
 		}
 		if(ui.actionOutputPostprocKeepParagraphs->isChecked()) {
 			sucChars += "\u2029"; // Keep if succeeded by line break

--- a/qt/src/OutputEditorText.cc
+++ b/qt/src/OutputEditorText.cc
@@ -136,8 +136,8 @@ void OutputEditorText::filterBuffer() {
 			preChars += "\\.\\?!"; // Keep if preceded by end mark (.?!)
 		}
 		if(ui.actionOutputPostprocKeepQuote->isChecked()) {
-			preChars += "'\"»«"; // Keep if preceded by quote
-			sucChars += "'\"«»"; // Keep if succeeded by quote
+			preChars += "'\"\u00BB\u00AB"; // Keep if preceded by quote
+			sucChars += "'\"\u00AB\u00BB"; // Keep if succeeded by quote
 		}
 		if(ui.actionOutputPostprocKeepParagraphs->isChecked()) {
 			sucChars += "\u2029"; // Keep if succeeded by line break


### PR DESCRIPTION
Hi,

here is the pull request. 
I added »« on both "sides" as both can mark opening and closing of quotes (see https://en.wikipedia.org/wiki/Guillemet).

Best,
Philip