### PR TITLE
[Qt] Fix bug in HOCRAttributeEditor constructor

### DIFF
--- a/qt/src/hocr/OutputEditorHOCR.cc
+++ b/qt/src/hocr/OutputEditorHOCR.cc
@@ -107,7 +107,7 @@ HOCRAttributeEditor::HOCRAttributeEditor(const QString& value, HOCRDocument* doc
 {
 	setFrame(false);
 	connect(m_doc, SIGNAL(itemAttributeChanged(QModelIndex,QString, QString)), this, SLOT(updateValue(QModelIndex,QString, QString)));
-	connect(this, SIGNAL(textChanged(QString)), this, SLOT(validateCahanges()));
+	connect(this, SIGNAL(textChanged(QString)), this, SLOT(validateChanges()));
 }
 
 void HOCRAttributeEditor::focusOutEvent(QFocusEvent *ev){


### PR DESCRIPTION
textChanged wasn't correctly triggering validateChanges.

Seems to have resolved some long hangs on ignoring words/adding words to dictionary. Haven't looked closely enough yet to be certain of why, but the typo's clear enough.