### PR TITLE
fix incomplete type 'QUrl' compile err in ubuntu 16.04

### DIFF
--- a/qt/src/hocr/HOCRPdfExporter.cc
+++ b/qt/src/hocr/HOCRPdfExporter.cc
@@ -27,6 +27,7 @@
 #include <QMessageBox>
 #include <QPainter>
 #include <QStandardItemModel>
+#include <QUrl>
 #include <podofo/base/PdfDictionary.h>
 #include <podofo/base/PdfFilter.h>
 #include <podofo/base/PdfStream.h>


### PR DESCRIPTION
when choose QT ui, Compile complain that Qurl is a imcomplete type.