### PR TITLE
[Qt] fix n-ary merge crash

### DIFF
--- a/qt/src/hocr/HOCRDocument.cc
+++ b/qt/src/hocr/HOCRDocument.cc
@@ -99,8 +99,8 @@ QModelIndex HOCRDocument::mergeItems(const QModelIndex& parent, int startRow, in
 		QString text = targetItem->text();
 		QRect bbox = targetItem->bbox();
 		beginRemoveRows(parent, startRow + 1, endRow);
-		for(int row = startRow + 1; row <= endRow; ++row) {
-			HOCRItem* item = static_cast<HOCRItem*>(parent.child(row, 0).internalPointer());
+		for(int row = ++startRow; row <= endRow; ++row) {
+			HOCRItem* item = static_cast<HOCRItem*>(parent.child(startRow, 0).internalPointer());
 			Q_ASSERT(item);
 			text += item->text();
 			bbox = bbox.united(item->bbox());
@@ -117,8 +117,8 @@ QModelIndex HOCRDocument::mergeItems(const QModelIndex& parent, int startRow, in
 		QRect bbox = targetItem->bbox();
 		QVector<HOCRItem*> moveChilds;
 		beginRemoveRows(parent, startRow + 1, endRow);
-		for(int row = startRow + 1; row <= endRow; ++row) {
-			HOCRItem* item = static_cast<HOCRItem*>(parent.child(row, 0).internalPointer());
+		for(int row = ++startRow; row <= endRow; ++row) {
+			HOCRItem* item = static_cast<HOCRItem*>(parent.child(startRow, 0).internalPointer());
 			Q_ASSERT(item);
 			moveChilds.append(item->takeChildren());
 			bbox = bbox.united(item->bbox());


### PR DESCRIPTION
Fixes #250.

`QModelIndex.child()` is implemented by way of `QAbstractItemModel`'s (i.e., `HOCRDocument`'s) `index()`, which retrieves children by index (row) from their parent's `m_childItems`. Therefore, calls to `child()` will reflect any deletions already made (since `deleteItem()` removes the item to delete from that vector).

The indexing here was as such incorrect and would try to retrieve items after those actually selected, causing bad behavior and, if reaching beyond the end of the child list, a segfault (on `->takeChildren`) and crash. (Yes, the Q_ASSERT here will fail—if compiled in, which tripped me up at first because I neglected that the CMake list defaults to Q_NO_DEBUG.)