### PR TITLE
[Qt] Add option to split textlines, paragraphs, and text blocks in HOCR editor

### DIFF
--- a/qt/src/hocr/HOCRDocument.cc
+++ b/qt/src/hocr/HOCRDocument.cc
@@ -231,10 +231,11 @@ bool HOCRDocument::removeItem(const QModelIndex& index) {
 	if(!item) {
 		return false;
 	}
-	recomputeBBoxes(item->parent());
+	HOCRItem* parentItem = item->parent();
 	beginRemoveRows(index.parent(), index.row(), index.row());
 	deleteItem(item);
 	endRemoveRows();
+	recomputeBBoxes(parentItem);
 	return true;
 }
 

--- a/qt/src/hocr/HOCRDocument.hh
+++ b/qt/src/hocr/HOCRDocument.hh
@@ -61,6 +61,7 @@ public:
 	QModelIndex moveItem(const QModelIndex& itemIndex, const QModelIndex& newParent, int row);
 	QModelIndex swapItems(const QModelIndex& parent, int startRow, int endRow);
 	QModelIndex mergeItems(const QModelIndex& parent, int startRow, int endRow);
+	QModelIndex splitItem(const QModelIndex& item, int startRow, int endRow);
 	QModelIndex addItem(const QModelIndex& parent, const QDomElement& element);
 	bool removeItem(const QModelIndex& index);
 

--- a/qt/src/hocr/HOCRDocument.hh
+++ b/qt/src/hocr/HOCRDocument.hh
@@ -99,7 +99,7 @@ private:
 	void deleteItem(HOCRItem* item);
 	void takeItem(HOCRItem* item);
 	void recursiveDataChanged(const QModelIndex& parent, const QVector<int>& roles, const QStringList& itemClasses = QStringList());
-	void recomputeParentBBoxes(const HOCRItem* item);
+	void recomputeBBoxes(HOCRItem* item);
 	HOCRItem* mutableItemAtIndex(const QModelIndex& index) const {
 		return index.isValid() ? static_cast<HOCRItem*>(index.internalPointer()) : nullptr;
 	}

--- a/qt/src/hocr/OutputEditorHOCR.cc
+++ b/qt/src/hocr/OutputEditorHOCR.cc
@@ -652,7 +652,8 @@ void OutputEditorHOCR::showTreeWidgetContextMenu(const QPoint& point) {
 			newIndex = m_document->swapItems(indices.first().parent(), rows.first(), rows.last());
 		}
 		if(newIndex.isValid()) {
-			ui.treeViewHOCR->selectionModel()->setCurrentIndex(newIndex, QItemSelectionModel::ClearAndSelect);
+			ui.treeViewHOCR->selectionModel()->setCurrentIndex(newIndex,
+					QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
 			showItemProperties(newIndex);
 		}
 		ui.treeViewHOCR->selectionModel()->blockSignals(false);

--- a/qt/src/hocr/OutputEditorHOCR.cc
+++ b/qt/src/hocr/OutputEditorHOCR.cc
@@ -626,9 +626,13 @@ void OutputEditorHOCR::showTreeWidgetContextMenu(const QPoint& point) {
 		bool sameClass = classes.size() == 1;
 
 		QAction* mergeAction = nullptr;
+		QAction* splitAction = nullptr;
 		QAction* swapAction = nullptr;
 		if(consecutive && !graphics && !pages && sameClass) { // Merging allowed
 			mergeAction = menu.addAction(_("Merge"));
+			if(firstItem->itemClass() != "ocr_carea") {
+				splitAction = menu.addAction(_("Split"));
+			}
 		}
 		if(nIndices == 2) { // Swapping allowed
 			swapAction = menu.addAction(_("Swap"));
@@ -642,6 +646,8 @@ void OutputEditorHOCR::showTreeWidgetContextMenu(const QPoint& point) {
 		QModelIndex newIndex;
 		if(clickedAction == mergeAction) {
 			newIndex = m_document->mergeItems(indices.first().parent(), rows.first(), rows.last());
+		} else if(clickedAction == splitAction) {
+			newIndex = m_document->splitItem(indices.first().parent(), rows.first(), rows.last());
 		} else if(clickedAction == swapAction) {
 			newIndex = m_document->swapItems(indices.first().parent(), rows.first(), rows.last());
 		}
@@ -665,22 +671,24 @@ void OutputEditorHOCR::showTreeWidgetContextMenu(const QPoint& point) {
 	QAction* actionAddPar = nullptr;
 	QAction* actionAddLine = nullptr;
 	QAction* actionAddWord = nullptr;
+	QAction* actionSplit = nullptr;
 	QAction* addWordAction = nullptr;
 	QAction* ignoreWordAction = nullptr;
 	QList<QAction*> setTextActions;
 	QAction* actionRemoveItem = nullptr;
 	QAction* actionExpand = nullptr;
 	QAction* actionCollapse = nullptr;
-	if(item->itemClass() == "ocr_page") {
+	QString itemClass = item->itemClass();
+	if(itemClass == "ocr_page") {
 		actionAddGraphic = menu.addAction(_("Add graphic region"));
 		actionAddCArea = menu.addAction(_("Add text block"));
-	} else if(item->itemClass() == "ocr_carea") {
+	} else if(itemClass == "ocr_carea") {
 		actionAddPar = menu.addAction(_("Add paragraph"));
-	} else if(item->itemClass() == "ocr_par") {
+	} else if(itemClass == "ocr_par") {
 		actionAddLine = menu.addAction(_("Add line"));
-	} else if(item->itemClass() == "ocr_line") {
+	} else if(itemClass == "ocr_line") {
 		actionAddWord = menu.addAction(_("Add word"));
-	} else if(item->itemClass() == "ocrx_word") {
+	} else if(itemClass == "ocrx_word") {
 		QString prefix, suffix, trimmedWord = HOCRItem::trimmedWord(item->text(), &prefix, &suffix);
 		QString spellLang = item->lang();
 		bool haveLanguage = true;
@@ -705,6 +713,9 @@ void OutputEditorHOCR::showTreeWidgetContextMenu(const QPoint& point) {
 	}
 	if(!menu.actions().isEmpty()) {
 		menu.addSeparator();
+	}
+	if(itemClass == "ocr_par" || itemClass == "ocr_line" || itemClass == "ocrx_word") {
+		actionSplit = menu.addAction(_("Split"));
 	}
 	actionRemoveItem = menu.addAction(_("Remove"));
 	actionRemoveItem->setShortcut(QKeySequence(Qt::Key_Delete));
@@ -735,6 +746,9 @@ void OutputEditorHOCR::showTreeWidgetContextMenu(const QPoint& point) {
 		m_document->recheckSpelling();
 	} else if(setTextActions.contains(clickedAction)) {
 		m_document->setData(index, clickedAction->text(), Qt::EditRole);
+	} else if(clickedAction == actionSplit) {
+		QModelIndex index = ui.treeViewHOCR->selectionModel()->currentIndex();
+		m_document->splitItem(index.parent(), index.row(), index.row());
 	} else if(clickedAction == actionRemoveItem) {
 		m_document->removeItem(ui.treeViewHOCR->selectionModel()->currentIndex());
 	} else if(clickedAction == actionExpand) {


### PR DESCRIPTION
Added this as I couldn't live without it anymore. (With merge and swap, any reordering is now technically possible, if not necessarily convenient.) Selecting a contiguous block of words, textlines, or paragraphs and then choosing "Split" from the context menu creates a new sibling adjacent to the parent and moves items in the block there.

Also fixes a bug in which removeItem did not correctly recompute ancestor bounding boxes.

I looked into extending the remove option to multiple items as well. Unfortunately, this resulted in irregular segfaults _after_ the return from showTreeWidgetContextMenu, and as I have never been able to get the crash backtrace to work I'm not sure what might be causing them.