### PR TITLE
More explicit PackageKit error message

### DIFF
--- a/gtk/src/TessdataManager.cc
+++ b/gtk/src/TessdataManager.cc
@@ -57,7 +57,7 @@ void TessdataManager::run() {
 		} catch(...) {
 		}
 		if(service_owner.empty()) {
-			Utils::message_dialog(Gtk::MESSAGE_ERROR, _("Error"), _("PackageKit is required for managing system-wide tesseract language packs, but it was not found. Please use the system package management software to manage the tesseract language packs, or switch to use the user tessdata path in the configuration dialog."));
+			Utils::message_dialog(Gtk::MESSAGE_ERROR, _("Error"), _("A session connection to the PackageKit backend is required for managing system-wide tesseract language packs, but it was not found. This service is usually provided by a software-management application such as Gnome Software. Please install software which provides the necessary PackageKit interface, use other system package management software to manage the tesseract language packs directly, or switch to using the user tessdata path in the configuration dialog."));
 			return;
 		}
 	}

--- a/qt/src/TessdataManager.cc
+++ b/qt/src/TessdataManager.cc
@@ -71,7 +71,7 @@ bool TessdataManager::setup() {
 		QDBusConnectionInterface* iface = QDBusConnection::sessionBus().interface();
 		iface->startService("org.freedesktop.PackageKit");
 		if(!iface->isServiceRegistered("org.freedesktop.PackageKit").value()) {
-			QMessageBox::critical(MAIN, _("Error"), _("PackageKit is required for managing system-wide tesseract language packs, but it was not found. Please use the system package management software to manage the tesseract language packs, or switch to use the user tessdata path in the configuration dialog."));
+			QMessageBox::critical(MAIN, _("Error"), _("A session connection to the PackageKit backend is required for managing system-wide tesseract language packs, but it was not found. This service is usually provided by a software-management application such as Gnome Software. Please install software which provides the necessary PackageKit interface, use other system package management software to manage the tesseract language packs directly, or switch to using the user tessdata path in the configuration dialog."));
 			return false;
 		}
 	}


### PR DESCRIPTION
The error message displayed when gImageReader cannot connect to `org.freedesktop.PackageKit.Modify` on the session bus makes it sound like PackageKit is missing from the system, when in reality the `.Modify` session service is provided by applications like Gnome Software, not by PackageKit itself.

This change updates the message to be more explicit about what exactly is missing, with the new text (identical in the Qt and Gtk sources) reading:

> A session connection to the PackageKit backend is required for managing
> system-wide tesseract language packs, but it was not found. This service is
> usually provided by a software-management application such as Gnome Software.
> Please install software which provides the necessary PackageKit interface,
> use other system package management software to manage the tesseract
> language packs directly, or switch to using the user tessdata path in the
> configuration dialog.