### PR TITLE
[Qt] don't allow Utils::documentsFolder() to supply nonexistent dirs

### DIFF
--- a/qt/src/Utils.cc
+++ b/qt/src/Utils.cc
@@ -45,7 +45,7 @@ QString Utils::documentsFolder() {
 #else
 	documentsFolder = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
 #endif
-	return documentsFolder.isEmpty() ? QDir::homePath() : documentsFolder;
+	return (documentsFolder.isEmpty() || !QDir(documentsFolder).exists()) ? QDir::homePath() : documentsFolder;
 }
 
 QString Utils::makeOutputFilename(const QString& filename) {


### PR DESCRIPTION
Qt5 guarantees that standard paths aren't empty, but not that they actually exist.

Most of this function's callers could already cope, but the crash handler tried to dump unsaved work in the returned location, which would totally fail.