### PR TITLE
[Qt] [hOCR] Allow three-letter language codes (ISO 639-2 and -3)

### DIFF
--- a/qt/src/Utils.cc
+++ b/qt/src/Utils.cc
@@ -203,10 +203,7 @@ QByteArray Utils::download(QUrl url, QString& messages, int timeout) {
 
 QString Utils::getSpellingLanguage(const QString& lang) {
 	// If it is already a valid code, return it
-	if(lang.length() == 2) {
-		return lang;
-	}
-	if(QRegExp("^[a-z]{2}_[A-Z]{2}").indexIn(lang) != -1) {
+	if(QRegExp("[a-z]{2,3}(_[A-Z]{2})?").exactMatch(lang)) {
 		return lang;
 	}
 	// Treat the language as a tesseract lang spec and try to find a matching code

--- a/qt/src/hocr/OutputEditorHOCR.cc
+++ b/qt/src/hocr/OutputEditorHOCR.cc
@@ -488,7 +488,7 @@ void OutputEditorHOCR::showItemProperties(const QModelIndex& index, const QModel
 QWidget* OutputEditorHOCR::createAttrWidget(const QModelIndex& itemIndex, const QString& attrName, const QString& attrValue, const QString& attrItemClass, bool multiple) {
 	static QMap<QString, QString> attrLineEdits = {
 		{"title:bbox", "\\d+\\s+\\d+\\s+\\d+\\s+\\d+"},
-		{"lang", "[a-z]{2}(?:_[A-Z]{2})?"},
+		{"lang", "[a-z]{2,3}(?:_[A-Z]{2})?"},
 		{"title:x_fsize", "\\d+"},
 		{"title:baseline", "[-+]?\\d+\\.?\\d*\\s[-+]?\\d+\\.?\\d*"}
 	};


### PR DESCRIPTION
I see now that this is analogous to your commit 84b6d82fd5d4e3ef248265aedd39227b526a49be (for GTK).

This is conservative and accepts only two- or three-letter language codes (based on ISO 639) and two-letter locales (based on my reading of ISO/IEC 15897), whereas 84b6d82fd5d4e3ef248265aedd39227b526a49be accepts 2+ letters for both. I don't think there are any actually extant identifiers on which they disagree, but I also don't know how this is supposed to work in Windows, so do whatever you think best.

(Not redundant with the Tesseract spec search as it handles scripts differently.)