### PR TITLE
[Qt] [hOCR] Propagate attributes down to manually added items 

### DIFF
--- a/qt/src/hocr/HOCRDocument.cc
+++ b/qt/src/hocr/HOCRDocument.cc
@@ -710,7 +710,8 @@ QMap<QString, QString> HOCRItem::getAttributes(const QList<QString>& names = QLi
 	return attrValues;
 }
 
-void HOCRItem::getPropagatableAttributes(QMap<QString, QMap<QString, QSet<QString>>>& occurences) const {
+// ocr_class:attr_key:attr_values
+void HOCRItem::getPropagatableAttributes(QMap<QString, QMap<QString, QSet<QString>>>& occurrences) const {
 	static QMap<QString, QStringList> s_propagatableAttributes = {
 		{"ocr_line", {"title:baseline"}},
 		{"ocrx_word", {"lang", "title:x_fsize", "title:x_font", "bold", "italic"}}
@@ -722,13 +723,13 @@ void HOCRItem::getPropagatableAttributes(QMap<QString, QMap<QString, QSet<QStrin
 		for(HOCRItem* child : m_childItems) {
 			QMap<QString, QString> attrs = child->getAttributes(it.value());
 			for(auto attrIt = attrs.begin(), attrItEnd = attrs.end(); attrIt != attrItEnd; ++attrIt) {
-				occurences[childClass][attrIt.key()].insert(attrIt.value());
+				occurrences[childClass][attrIt.key()].insert(attrIt.value());
 			}
 		}
 	}
 	if(childClass != "ocrx_word") {
 		for(HOCRItem* child : m_childItems) {
-			child->getPropagatableAttributes(occurences);
+			child->getPropagatableAttributes(occurrences);
 		}
 	}
 }

--- a/qt/src/hocr/OutputEditorHOCR.cc
+++ b/qt/src/hocr/OutputEditorHOCR.cc
@@ -440,9 +440,9 @@ void OutputEditorHOCR::showItemProperties(const QModelIndex& index, const QModel
 	}
 
 	// ocr_class:attr_key:attr_values
-	QMap<QString, QMap<QString, QSet<QString>>> occurences;
-	currentItem->getPropagatableAttributes(occurences);
-	for(auto it = occurences.begin(), itEnd = occurences.end(); it != itEnd; ++it) {
+	QMap<QString, QMap<QString, QSet<QString>>> occurrences;
+	currentItem->getPropagatableAttributes(occurrences);
+	for(auto it = occurrences.begin(), itEnd = occurrences.end(); it != itEnd; ++it) {
 		ui.tableWidgetProperties->insertRow(++row);
 		QTableWidgetItem* sectionItem = new QTableWidgetItem(it.key());
 		sectionItem->setFlags(sectionItem->flags() & ~(Qt::ItemIsEditable | Qt::ItemIsSelectable));


### PR DESCRIPTION
When creating a manually added hOCR item, if an attribute is propagatable to the item's class and all of the item's relatives agree on its value, apply the consensus value to the new item as well. Very minor QoL improvement.