### PR TITLE
[Qt] [hOCR] Don't auto-replace all dashes at the ends of lines

### DIFF
--- a/qt/src/hocr/HOCRDocument.cc
+++ b/qt/src/hocr/HOCRDocument.cc
@@ -620,11 +620,6 @@ HOCRItem::HOCRItem(const QDomElement& element, HOCRPage* page, HOCRItem* parent,
 		m_text = element.text();
 		m_bold = !element.elementsByTagName("strong").isEmpty();
 		m_italic = !element.elementsByTagName("em").isEmpty();
-		// For the last word items of the line, ensure the correct hyphen is used
-		QDomElement nextElement = element.nextSiblingElement();
-		if(nextElement.isNull()) {
-			m_text.replace(QRegExp("[-\u2014]\\s*$"), "-");
-		}
 	} else if(itemClass() == "ocr_line") {
 		// Depending on the locale, tesseract can use a comma instead of a dot as decimal separator in the baseline...
 		m_titleAttrs["baseline"] = m_titleAttrs["baseline"].replace(",", ".");


### PR DESCRIPTION
Sometimes they really are typeset like that. I corrected a number of them multiple times before I realized gIR was "fixing" them every time I opened the file.

I know character-accurate hyphenation is important for search, but as it is there's no way to opt out of this. (FWIW, I've never seen Tesseract in hOCR mode recognize an em-dash incorrectly or an en-dash at all.)

I've been thinking about advanced search (using tree structure and maybe attribute values along with text content), which would be handy for doing this more carefully as well as for some formatting issues, but it's not fully baked yet, sorry.