### PR TITLE
[Qt] [hOCR] Improve selection behavior after adding elements

### DIFF
--- a/qt/src/hocr/OutputEditorHOCR.cc
+++ b/qt/src/hocr/OutputEditorHOCR.cc
@@ -602,7 +602,7 @@ void OutputEditorHOCR::bboxDrawn(const QRect& bbox, int action) {
 	}
 	QModelIndex index = m_document->addItem(current, newElement);
 	if(index.isValid()) {
-		ui.treeViewHOCR->selectionModel()->setCurrentIndex(index, QItemSelectionModel::ClearAndSelect);
+		ui.treeViewHOCR->selectionModel()->setCurrentIndex(index, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
 	}
 }
 


### PR DESCRIPTION
Makes adding consistent with the rest of the actions that alter the tree. (In particular, it's now possible to add an item, select another item, and immediately swap them, where before the context menu would behave as though only the other element was selected.)