### PR TITLE
[Qt] [hOCR] Correctly trim words followed by superscript numbers

### DIFF
--- a/qt/src/hocr/HOCRDocument.cc
+++ b/qt/src/hocr/HOCRDocument.cc
@@ -607,8 +607,8 @@ QString HOCRItem::serializeAttrGroup(const QMap<QString, QString>& attrs) {
 }
 
 QString HOCRItem::trimmedWord(const QString& word, QString* prefix, QString* suffix) {
-	// correctly trim words with apostrophes or hyphens within them and initialisms/acronyms
-	QRegExp wordRe("^(\\W*)(\\w|\\w(\\w|[-'’])*\\w|(\\w+\\.){2,})(\\W*)$");
+	// correctly trim words with apostrophes or hyphens within them, initialisms/acronyms, and numeric citations
+	QRegExp wordRe("^(\\W*)(\\w|\\w(\\w|[-'’])*\\w|(\\w+\\.){2,})([\\W\\x00b2\\x00b3\\x00b9\\x2070-\\x207e]*)$");
 	if(wordRe.indexIn(word) != -1) {
 		if(prefix) {
 			*prefix = wordRe.cap(1);


### PR DESCRIPTION
The 'non-word' character class doesn't catch them since they're numbers. This isn't pretty, but I run into it a lot.