### PR TITLE
[Qt] [hOCR] Rework spellcheck to handle unspaced dashes

### DIFF
--- a/qt/src/hocr/HOCRDocument.cc
+++ b/qt/src/hocr/HOCRDocument.cc
@@ -24,6 +24,7 @@
 #include <QSet>
 #include <QTextStream>
 #include <QtSpell.hpp>
+#include <cmath>
 
 #include "common.hh"
 #include "HOCRDocument.hh"
@@ -286,7 +287,55 @@ QModelIndex HOCRDocument::prevIndex(const QModelIndex& current) {
 }
 
 bool HOCRDocument::indexIsMisspelledWord(const QModelIndex& index) const {
-	return !checkItemSpelling(itemAtIndex(index));
+	return !checkItemSpelling(index);
+}
+
+bool HOCRDocument::checkItemSpelling(const QModelIndex& index, QStringList* suggestions, int limit) const {
+	const HOCRItem* item = itemAtIndex(index);
+	if(item->itemClass() != "ocrx_word") { return true; }
+
+	QString prefix, suffix, trimmed = HOCRItem::trimmedWord(item->text(), &prefix, &suffix);
+	if(trimmed.isEmpty()) { return true; }
+	QString lang = item->lang();
+	if(m_spell->getLanguage() != lang && !(m_spell->setLanguage(lang))) { return true; }
+
+	// check word, including (if requested) setting suggestions; handle hyphenated phrases correctly
+	if(checkSpelling(trimmed, suggestions, limit)) { return true; }
+
+	// handle some hyphenated words
+	// don't bother with words not broken over sibling text lines (ie interrupted by other blocks), it's human hard
+	// don't bother with words broken over three or more lines, it's implausible and this treatment is ^ necessarily incomplete
+	HOCRItem* parent = item->parent();
+	if(!parent) { return false; }
+	HOCRItem* grandparent = parent->parent();
+	if(!grandparent) { return false; }
+	int idx = item->index();
+	int parentIdx = parent->index();
+	QVector<HOCRItem*> parentSiblings = grandparent->children();
+	if(idx == 0 && parentIdx > 0) {
+		HOCRItem* parentPrevSibling = parentSiblings.at(parentIdx-1);
+		if(!parentPrevSibling) { return false; }
+		QVector<HOCRItem*> cousins = parentPrevSibling->children();
+		if(cousins.size() < 1) { return false; }
+		HOCRItem* prevCousin = cousins.back();
+		if(!prevCousin || prevCousin->itemClass() != "ocrx_word") { return false; }
+		QString prevText = prevCousin->text();
+		if(prevText.isEmpty() || prevText.back() != '-') { return false; }
+
+		// don't bother with (reassembled) suggestions for broken words since we can't re-break them
+		return checkSpelling(HOCRItem::trimmedWord(prevText) + trimmed);
+	}
+	if(idx + 1 == parent->children().size() && parentIdx + 1 < parentSiblings.size() && item->text().back() == '-') {
+		HOCRItem* parentNextSibling = parentSiblings.at(parentIdx + 1);
+		if(!parentNextSibling) { return false; }
+		QVector<HOCRItem*> cousins = parentNextSibling->children();
+		if(cousins.size() < 1) { return false; }
+		HOCRItem* nextCousin = cousins.front();
+		if(!nextCousin || nextCousin->itemClass() != "ocrx_word") { return false; }
+
+		return checkSpelling(trimmed + HOCRItem::trimmedWord(nextCousin->text()));
+	}
+	return false;
 }
 
 bool HOCRDocument::referencesSource(const QString& filename) const {
@@ -359,9 +408,9 @@ QVariant HOCRDocument::data(const QModelIndex& index, int role) const {
 				parent = parent->parent();
 			}
 			if(enabled) {
-				return checkItemSpelling(item) ? QVariant() : QVariant(QColor(Qt::red));
+				return checkItemSpelling(index) ? QVariant() : QVariant(QColor(Qt::red));
 			} else {
-				return checkItemSpelling(item) ? QVariant(QColor(Qt::gray)) : QVariant(QColor(208, 80, 82));
+				return checkItemSpelling(index) ? QVariant(QColor(Qt::gray)) : QVariant(QColor(208, 80, 82));
 			}
 		}
 		case Qt::CheckStateRole:
@@ -508,50 +557,59 @@ QIcon HOCRDocument::decorationRoleForItem(const HOCRItem* item) const {
 	return QIcon();
 }
 
-bool HOCRDocument::checkItemSpelling(const HOCRItem* item) const {
-	if(item->itemClass() != "ocrx_word") { return true; }
-
-	QString trimmed = HOCRItem::trimmedWord(item->text());
-	if(trimmed.isEmpty()) { return true; }
-
-	QString lang = item->lang();
-	if(m_spell->getLanguage() != lang && !(m_spell->setLanguage(lang))) { return true; }
-
-	if(m_spell->checkWord(trimmed)) { return true; } // handle hyphenated phrases correctly
-
-	// handle some hyphenated words
-	// don't bother with words not broken over sibling text lines (ie interrupted by other blocks), it's human hard
-	// don't bother with words broken over three or more lines, it's implausible and this treatment is ^ necessarily incomplete
-	HOCRItem* parent = item->parent();
-	if(!parent) { return false; }
-	HOCRItem* grandparent = parent->parent();
-	if(!grandparent) { return false; }
-	int idx = item->index();
-	int parentIdx = parent->index();
-	QVector<HOCRItem*> parentSiblings = grandparent->children();
-	if(idx == 0 && parentIdx > 0) {
-		HOCRItem* parentPrevSibling = parentSiblings.at(parentIdx - 1);
-		if(!parentPrevSibling) { return false; }
-		QVector<HOCRItem*> cousins = parentPrevSibling->children();
-		if(cousins.size() < 1) { return false; }
-		HOCRItem* prevCousin = cousins.back();
-		if(!prevCousin || prevCousin->itemClass() != "ocrx_word") { return false; }
-		QString prevText = prevCousin->text();
-		if(prevText.isEmpty() || prevText.back() != '-') { return false; }
-
-		return m_spell->checkWord(HOCRItem::trimmedWord(prevText) + trimmed);
+bool HOCRDocument::checkSpelling(const QString& trimmed, QStringList* suggestions, int limit) const {
+	QVector<QStringRef> words = trimmed.splitRef(QRegExp("[\\x2013\\x2014]+"));
+	int perWordLimit;
+	// s = p^w => w = log_p(c) = log(c)/log(p) => p = 10^(log(c)/w)
+	if(limit > 0) { perWordLimit = int(std::pow(10, std::log10(limit) / words.size())); }
+	QList<QList<QString>> wordSuggestions;
+	bool valid = true;
+	for(const QStringRef& word : words) {
+		QString wordString = word.toString();
+		bool wordValid = m_spell->checkWord(wordString);
+		valid &= wordValid;
+		if(suggestions) {
+			QList<QString> ws = m_spell->getSpellingSuggestions(wordString);
+			if(wordValid) { ws.prepend(wordString); }
+			if(limit == -1) {
+				wordSuggestions.append(ws);
+			} else if(limit > 0) {
+				wordSuggestions.append(ws.mid(0, perWordLimit));
+			}
+		}
 	}
-	if(idx + 1 == parent->children().size() && parentIdx + 1 < parentSiblings.size() && item->text().back() == '-') {
-		HOCRItem* parentNextSibling = parentSiblings.at(parentIdx + 1);
-		if(!parentNextSibling) { return false; }
-		QVector<HOCRItem*> cousins = parentNextSibling->children();
-		if(cousins.size() < 1) { return false; }
-		HOCRItem* nextCousin = cousins.front();
-		if(!nextCousin || nextCousin->itemClass() != "ocrx_word") { return false; }
-
-		return m_spell->checkWord(trimmed + HOCRItem::trimmedWord(nextCousin->text()));
+	if(suggestions) {
+		suggestions->clear();
+		QList<QList<QString>> suggestionCombinations;
+		generateCombinations(wordSuggestions, suggestionCombinations, 0, QList<QString>());
+		for(const QList<QString>& combination : suggestionCombinations) {
+			QString s = "";
+			const QStringRef* originalWord = words.begin();
+			int last = 0;
+			int next;
+			for(const QString& suggestedWord : combination) {
+				next = originalWord->position();
+				s.append(trimmed.midRef(last, next - last));
+				s.append(suggestedWord);
+				last = next + originalWord->length();
+				originalWord++;
+			}
+			s.append(trimmed.midRef(last));
+			suggestions->append(s);
+		}
 	}
-	return false;
+	return valid;
+}
+
+// each suggestion for each word => each word in each suggestion
+void HOCRDocument::generateCombinations(const QList<QList<QString>>& lists, QList<QList<QString>>& results, int depth, const QList<QString> c) const {
+	if(depth == lists.size()) {
+		results.append(c);
+		return;
+	}
+	for(int i = 0; i < lists[depth].size(); ++i) {
+		generateCombinations(lists, results, depth + 1, c + QList<QString>({lists[depth][i]}));
+	}
 }
 
 void HOCRDocument::insertItem(HOCRItem* parent, HOCRItem* item, int i) {
@@ -607,8 +665,8 @@ QString HOCRItem::serializeAttrGroup(const QMap<QString, QString>& attrs) {
 }
 
 QString HOCRItem::trimmedWord(const QString& word, QString* prefix, QString* suffix) {
-	// correctly trim words with apostrophes or hyphens within them, initialisms/acronyms, and numeric citations
-	QRegExp wordRe("^(\\W*)(\\w|\\w(\\w|[-'’])*\\w|(\\w+\\.){2,})([\\W\\x00b2\\x00b3\\x00b9\\x2070-\\x207e]*)$");
+	// correctly trim words with apostrophes or hyphens within them, phrases with dashes, initialisms/acronyms, and numeric citations
+	QRegExp wordRe("^(\\W*)(\\w|\\w(\\w|[-\\x2013\\x2014'’])*\\w|(\\w+\\.){2,})([\\W\\x00b2\\x00b3\\x00b9\\x2070-\\x207e]*)$");
 	if(wordRe.indexIn(word) != -1) {
 		if(prefix) {
 			*prefix = wordRe.cap(1);

--- a/qt/src/hocr/HOCRDocument.cc
+++ b/qt/src/hocr/HOCRDocument.cc
@@ -666,7 +666,7 @@ QString HOCRItem::serializeAttrGroup(const QMap<QString, QString>& attrs) {
 
 QString HOCRItem::trimmedWord(const QString& word, QString* prefix, QString* suffix) {
 	// correctly trim words with apostrophes or hyphens within them, phrases with dashes, initialisms/acronyms, and numeric citations
-	QRegExp wordRe("^(\\W*)(\\w|\\w(\\w|[-\\x2013\\x2014'’])*\\w|(\\w+\\.){2,})([\\W\\x00b2\\x00b3\\x00b9\\x2070-\\x207e]*)$");
+	QRegExp wordRe("^(\\W*)(\\w?|\\w(\\w|[-\\x2013\\x2014'’])*\\w|(\\w+\\.){2,})([\\W\\x00b2\\x00b3\\x00b9\\x2070-\\x207e]*)$");
 	if(wordRe.indexIn(word) != -1) {
 		if(prefix) {
 			*prefix = wordRe.cap(1);

--- a/qt/src/hocr/HOCRDocument.cc
+++ b/qt/src/hocr/HOCRDocument.cc
@@ -564,13 +564,14 @@ bool HOCRDocument::checkSpelling(const QString& trimmed, QStringList* suggestion
 	if(limit > 0) { perWordLimit = int(std::pow(10, std::log10(limit) / words.size())); }
 	QList<QList<QString>> wordSuggestions;
 	bool valid = true;
+	bool multipleWords = words.size() > 1;
 	for(const QStringRef& word : words) {
 		QString wordString = word.toString();
 		bool wordValid = m_spell->checkWord(wordString);
 		valid &= wordValid;
 		if(suggestions) {
 			QList<QString> ws = m_spell->getSpellingSuggestions(wordString);
-			if(wordValid) { ws.prepend(wordString); }
+			if(wordValid && multipleWords) { ws.prepend(wordString); }
 			if(limit == -1) {
 				wordSuggestions.append(ws);
 			} else if(limit > 0) {

--- a/qt/src/hocr/HOCRDocument.hh
+++ b/qt/src/hocr/HOCRDocument.hh
@@ -68,6 +68,7 @@ public:
 	QModelIndex nextIndex(const QModelIndex& current);
 	QModelIndex prevIndex(const QModelIndex& current);
 	bool indexIsMisspelledWord(const QModelIndex& index) const;
+	bool checkItemSpelling(const QModelIndex&, QStringList* suggestions = nullptr, int limit = -1) const;
 
 	bool referencesSource(const QString& filename) const;
 	QModelIndex searchPage(const QString& filename, int pageNr) const;
@@ -95,7 +96,8 @@ private:
 	QString displayRoleForItem(const HOCRItem* item) const;
 	QIcon decorationRoleForItem(const HOCRItem* item) const;
 
-	bool checkItemSpelling(const HOCRItem* item) const;
+	bool checkSpelling(const QString& trimmed, QStringList* suggestions = nullptr, int limit = -1) const;
+	void generateCombinations(const QList<QList<QString>>& lists, QList<QList<QString>>& results, int depth, const QList<QString> c) const;
 	void insertItem(HOCRItem* parent, HOCRItem* item, int i);
 	void deleteItem(HOCRItem* item);
 	void takeItem(HOCRItem* item);

--- a/qt/src/hocr/OutputEditorHOCR.cc
+++ b/qt/src/hocr/OutputEditorHOCR.cc
@@ -700,19 +700,16 @@ void OutputEditorHOCR::showTreeWidgetContextMenu(const QPoint& point) {
 		actionAddWord = menu.addAction(_("Add word"));
 	} else if(itemClass == "ocrx_word") {
 		QString prefix, suffix, trimmedWord = HOCRItem::trimmedWord(item->text(), &prefix, &suffix);
-		QString spellLang = item->lang();
-		bool haveLanguage = true;
-		if(m_spell.getLanguage() != spellLang) {
-			haveLanguage = m_spell.setLanguage(spellLang);
+		QStringList suggestions;
+		bool valid = m_document->checkItemSpelling(index, &suggestions, 16);
+		for(const QString& suggestion : suggestions) {
+			setTextActions.append(menu.addAction(prefix + suggestion + suffix));
 		}
-		if(!trimmedWord.isEmpty() && haveLanguage) {
-			for(const QString& suggestion : m_spell.getSpellingSuggestions(trimmedWord)) {
-				setTextActions.append(menu.addAction(prefix + suggestion + suffix));
-			}
+		if(!trimmedWord.isEmpty()) {
 			if(setTextActions.isEmpty()) {
 				menu.addAction(_("No suggestions"))->setEnabled(false);
 			}
-			if(!m_spell.checkWord(trimmedWord)) {
+			if(!valid) {
 				menu.addSeparator();
 				actionDictAddWord = menu.addAction(_("Add to dictionary"));
 				actionDictAddWord->setData(trimmedWord);

--- a/qt/src/hocr/OutputEditorHOCR.cc
+++ b/qt/src/hocr/OutputEditorHOCR.cc
@@ -634,17 +634,17 @@ void OutputEditorHOCR::showTreeWidgetContextMenu(const QPoint& point) {
 		bool pages = firstItem->itemClass() == "ocr_page";
 		bool sameClass = classes.size() == 1;
 
-		QAction* mergeAction = nullptr;
-		QAction* splitAction = nullptr;
-		QAction* swapAction = nullptr;
+		QAction* actionMerge = nullptr;
+		QAction* actionSplit = nullptr;
+		QAction* actionSwap = nullptr;
 		if(consecutive && !graphics && !pages && sameClass) { // Merging allowed
-			mergeAction = menu.addAction(_("Merge"));
+			actionMerge = menu.addAction(_("Merge"));
 			if(firstItem->itemClass() != "ocr_carea") {
-				splitAction = menu.addAction(_("Split from parent"));
+				actionSplit = menu.addAction(_("Split from parent"));
 			}
 		}
 		if(nIndices == 2) { // Swapping allowed
-			swapAction = menu.addAction(_("Swap"));
+			actionSwap = menu.addAction(_("Swap"));
 		}
 
 		QAction* clickedAction = menu.exec(ui.treeViewHOCR->mapToGlobal(point));
@@ -653,12 +653,12 @@ void OutputEditorHOCR::showTreeWidgetContextMenu(const QPoint& point) {
 		}
 		ui.treeViewHOCR->selectionModel()->blockSignals(true);
 		QModelIndex newIndex;
-		if(clickedAction == mergeAction) {
+		if(clickedAction == actionMerge) {
 			newIndex = m_document->mergeItems(indices.first().parent(), rows.first(), rows.last());
-		} else if(clickedAction == splitAction) {
+		} else if(clickedAction == actionSplit) {
 			newIndex = m_document->splitItem(indices.first().parent(), rows.first(), rows.last());
 			expandCollapseChildren(newIndex, true);
-		} else if(clickedAction == swapAction) {
+		} else if(clickedAction == actionSwap) {
 			newIndex = m_document->swapItems(indices.first().parent(), rows.first(), rows.last());
 		}
 		if(newIndex.isValid()) {
@@ -682,10 +682,10 @@ void OutputEditorHOCR::showTreeWidgetContextMenu(const QPoint& point) {
 	QAction* actionAddLine = nullptr;
 	QAction* actionAddWord = nullptr;
 	QAction* actionSplit = nullptr;
-	QAction* addWordAction = nullptr;
-	QAction* ignoreWordAction = nullptr;
+	QAction* actionDictAddWord = nullptr;
+	QAction* actionDictIgnoreWord = nullptr;
 	QList<QAction*> setTextActions;
-	QAction* actionRemoveItem = nullptr;
+	QAction* actionRemove = nullptr;
 	QAction* actionExpand = nullptr;
 	QAction* actionCollapse = nullptr;
 	QString itemClass = item->itemClass();
@@ -714,10 +714,10 @@ void OutputEditorHOCR::showTreeWidgetContextMenu(const QPoint& point) {
 			}
 			if(!m_spell.checkWord(trimmedWord)) {
 				menu.addSeparator();
-				addWordAction = menu.addAction(_("Add to dictionary"));
-				addWordAction->setData(trimmedWord);
-				ignoreWordAction = menu.addAction(_("Ignore word"));
-				ignoreWordAction->setData(trimmedWord);
+				actionDictAddWord = menu.addAction(_("Add to dictionary"));
+				actionDictAddWord->setData(trimmedWord);
+				actionDictIgnoreWord = menu.addAction(_("Ignore word"));
+				actionDictIgnoreWord->setData(trimmedWord);
 			}
 		}
 	}
@@ -727,8 +727,8 @@ void OutputEditorHOCR::showTreeWidgetContextMenu(const QPoint& point) {
 	if(itemClass == "ocr_par" || itemClass == "ocr_line" || itemClass == "ocrx_word") {
 		actionSplit = menu.addAction(_("Split from parent"));
 	}
-	actionRemoveItem = menu.addAction(_("Remove"));
-	actionRemoveItem->setShortcut(QKeySequence(Qt::Key_Delete));
+	actionRemove = menu.addAction(_("Remove"));
+	actionRemove->setShortcut(QKeySequence(Qt::Key_Delete));
 	if(m_document->rowCount(index) > 0) {
 		actionExpand = menu.addAction(_("Expand all"));
 		actionCollapse = menu.addAction(_("Collapse all"));
@@ -748,11 +748,11 @@ void OutputEditorHOCR::showTreeWidgetContextMenu(const QPoint& point) {
 		m_tool->setAction(DisplayerToolHOCR::ACTION_DRAW_LINE_RECT);
 	} else if(clickedAction == actionAddWord) {
 		m_tool->setAction(DisplayerToolHOCR::ACTION_DRAW_WORD_RECT);
-	} else if(clickedAction == addWordAction) {
-		m_spell.addWordToDictionary(addWordAction->data().toString());
+	} else if(clickedAction == actionDictAddWord) {
+		m_spell.addWordToDictionary(actionDictAddWord->data().toString());
 		m_document->recheckSpelling();
-	} else if(clickedAction == ignoreWordAction) {
-		m_spell.ignoreWord(ignoreWordAction->data().toString());
+	} else if(clickedAction == actionDictIgnoreWord) {
+		m_spell.ignoreWord(actionDictIgnoreWord->data().toString());
 		m_document->recheckSpelling();
 	} else if(setTextActions.contains(clickedAction)) {
 		m_document->setData(index, clickedAction->text(), Qt::EditRole);
@@ -760,7 +760,7 @@ void OutputEditorHOCR::showTreeWidgetContextMenu(const QPoint& point) {
 		QModelIndex newIndex = m_document->splitItem(index.parent(), index.row(), index.row());
 		ui.treeViewHOCR->selectionModel()->setCurrentIndex(newIndex, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
 		expandCollapseChildren(newIndex, true);
-	} else if(clickedAction == actionRemoveItem) {
+	} else if(clickedAction == actionRemove) {
 		m_document->removeItem(ui.treeViewHOCR->selectionModel()->currentIndex());
 	} else if(clickedAction == actionExpand) {
 		expandCollapseChildren(index, true);


### PR DESCRIPTION
Resolves #362.

Changes `HOCRDocument` API slightly; `checkItemSpelling` is now public (taking an index) and should be used both for checking validity and (optionally) requesting suggestions.