### PR TITLE
[Qt] [hOCR] Add option to specify DPI of image sources when exporting to PDF

### DIFF
--- a/qt/data/PdfExportDialog.ui
+++ b/qt/data/PdfExportDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>495</width>
-    <height>632</height>
+    <width>502</width>
+    <height>651</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <property name="horizontalSpacing">
     <number>2</number>
    </property>
-   <item row="3" column="0" colspan="2">
+   <item row="4" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -30,7 +30,7 @@
      </property>
     </spacer>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item row="5" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -47,7 +47,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0" colspan="2">
+   <item row="3" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
       <number>0</number>
@@ -82,6 +82,20 @@
          <property name="text">
           <string>Backend:</string>
          </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="comboBoxOutputMode">
+         <item>
+          <property name="text">
+           <string>PDF</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>PDF with invisible text overlay</string>
+          </property>
+         </item>
         </widget>
        </item>
        <item row="3" column="1">
@@ -177,20 +191,6 @@
            </widget>
           </item>
          </layout>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QComboBox" name="comboBoxOutputMode">
-         <item>
-          <property name="text">
-           <string>PDF</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>PDF with invisible text overlay</string>
-          </property>
-         </item>
         </widget>
        </item>
        <item row="3" column="0">
@@ -547,6 +547,50 @@
           </item>
           <item row="1" column="1" colspan="2">
            <widget class="QFontComboBox" name="comboBoxFallbackFontFamily"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QWidget" name="widgetPaperSizeDpi" native="true">
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <property name="spacing">
+           <number>6</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="labelPaperSizeDpi">
+            <property name="text">
+             <string>Treat image sources as having true DPI:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="spinBoxPaperSizeDpi">
+            <property name="minimum">
+             <number>50</number>
+            </property>
+            <property name="maximum">
+             <number>1200</number>
+            </property>
+            <property name="singleStep">
+             <number>10</number>
+            </property>
+            <property name="value">
+             <number>300</number>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/qt/src/hocr/HOCRPdfExporter.cc
+++ b/qt/src/hocr/HOCRPdfExporter.cc
@@ -559,7 +559,7 @@ bool HOCRPdfExporter::run(QString& filebasename) {
 				int sourceDpi = page->resolution();
 				int sourceScale = sourceDpi;
 				if(isImage) {
-					sourceDpi = ui.spinBoxPaperSizeDpi->value();
+					sourceDpi *= ui.spinBoxPaperSizeDpi->value() / 100;
 				}
 				// [pt] = 72 * [in]
 				// [in] = 1 / dpi * [px]

--- a/qt/src/hocr/HOCRPdfExporter.cc
+++ b/qt/src/hocr/HOCRPdfExporter.cc
@@ -826,7 +826,8 @@ void HOCRPdfExporter::imageFormatChanged() {
 	QStandardItem* ccittItem = model->item(ccittIdx);
 	QStandardItem* jpegItem = model->item(jpegIdx);
 	if(format == QImage::Format_Mono) {
-		if(ui.comboBoxImageCompression->currentIndex() == jpegIdx) {
+		// for monochrome images, allow zip and ccitt4 (but not jpeg, unless QPrinter is forcing us)
+		if(ui.comboBoxImageCompression->currentIndex() == jpegIdx && ui.comboBoxBackend->itemData(ui.comboBoxBackend->currentIndex()).toInt() != BackendQPrinter) {
 			ui.comboBoxImageCompression->setCurrentIndex(zipIdx);
 		}
 		ccittItem->setFlags(ccittItem->flags() | Qt::ItemIsSelectable | Qt::ItemIsEnabled);
@@ -834,6 +835,7 @@ void HOCRPdfExporter::imageFormatChanged() {
 		ui.labelDithering->setEnabled(true);
 		ui.comboBoxDithering->setEnabled(true);
 	} else {
+		// for color and grayscale images, allow jpeg and zip (but not ccitt4)
 		if(ui.comboBoxImageCompression->currentIndex() == ccittIdx) {
 			ui.comboBoxImageCompression->setCurrentIndex(zipIdx);
 		}

--- a/qt/src/hocr/HOCRPdfExporter.hh
+++ b/qt/src/hocr/HOCRPdfExporter.hh
@@ -106,7 +106,7 @@ private:
 
 	PDFSettings getPdfSettings() const;
 	PDFPainter* createPoDoFoPrinter(const QString& filename, const QFont& defaultFont, QString& errMsg);
-	void printChildren(PDFPainter& painter, const HOCRItem* item, const PDFSettings& pdfSettings, double px2pu, double imgScale = 1.);
+	void printChildren(PDFPainter& painter, const HOCRItem* item, const PDFSettings& pdfSettings, double px2pu, double imgScale = 1., double fontScale = 1.);
 
 private slots:
 	void backendChanged();


### PR DESCRIPTION
Resolves #350.

The logic calculating output sizes coped poorly with image sources, since their "resolution" is actually the (percentage) scale factor used for recognizing. gIR would go ahead and interpret it as a physical ratio during export to PDF, leading to blowups in reported physical sizes, in image dimensions, and in file sizes if the user chose an accurate resolution. (For example, a a 7"×10" document scanned at 300 DPI into a 2100×3000 image file and recognized at 100% would, if exported at 300 DPI, result in a 21"×30" document containing a 6300×9000 image, for a serious inflation of the filesize.) It was possible to adjust the image dimensions by accounting for this behavior during the export, but not the physical size.

This adds an 'image source DPI' setting to the PDF export window, allowing gIR to perform image dimension _and_ DPI calculations accurately using a user-provided figure. (And arbitrary scaling with independent up/down-sampling, if you're into that. But I figured that the source and target DPI are what the user is most likely to have on hand.)

Edit: oh, also fixes #354 (albeit with different methodology. Actually, should this be allowed even when paper size is different from source? Might be handy to be able to both scale and crop/pad). I knew I'd seen more discussion of this around somewhere.