### PR TITLE
Configure LGTM.com C/C++ code analysis

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,10 @@
+extraction:
+  cpp:
+    prepare:
+      packages:
+        - python3-gi
+    configure:
+      command:
+        - mkdir _lgtm_build_dir
+        - cd _lgtm_build_dir
+        - cmake  -DINTERFACE_TYPE=gtk ..

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Translation status](https://hosted.weblate.org/widgets/gimagereader/-/svg-badge.svg)](https://hosted.weblate.org/engage/gimagereader/?utm_source=widget)
+[![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/manisandro/gImageReader.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/manisandro/gImageReader/context:cpp)
+
 
 gImageReader
 ============


### PR DESCRIPTION
Hi team!

@stweil (from the [Tesseract](https://github.com/tesseract-ocr/tesseract) project) reported that `gImageReader` wasn't successfully analysed on LGTM.com due to a build problem: https://discuss.lgtm.com/t/c-language-not-detected/1401

The fix is fairly straightforward: use `cmake -DINTERFACE_TYPE=gtk` (the default cmake target depends on `libqtspell-qt5-dev` which isn't available in Ubuntu Bionic). Here's the `lgtm.yml` configuration that makes it work; hope that's helpful. 

LGTM.com will automatically pick up any changes to this configuration file ([see documentation for details](https://lgtm.com/help/lgtm/lgtm.yml-configuration-file)), for example if your build process changes in the future. Any questions: give me a shout.

If you like you can enable automated code review for pull requests [here](https://lgtm.com/projects/g/manisandro/gImageReader/ci). Here's an example of how the AMPHTML project use that: https://github.com/ampproject/amphtml/pull/13060.

(Full disclosure: I'm part of the team that built LGTM.com)