### PR TITLE
Fix FTBFS with Tesseract 5.0-alpha

### DIFF
--- a/qt/src/Recognizer.hh
+++ b/qt/src/Recognizer.hh
@@ -21,6 +21,7 @@
 #define RECOGNIZER_HPP
 
 #include <QToolButton>
+#include <memory>
 
 #include "Config.hh"
 #include "Displayer.hh"
@@ -79,7 +80,7 @@ private:
 	QString m_langLabel;
 	Config::Lang m_curLang;
 
-	tesseract::TessBaseAPI initTesseract(const char* language = nullptr, bool* ok = nullptr) const;
+	std::unique_ptr<tesseract::TessBaseAPI> initTesseract(const char* language = nullptr, bool* ok = nullptr) const;
 	QList<int> selectPages(bool& autodetectLayout);
 	void recognize(const QList<int>& pages, bool autodetectLayout = false);
 	bool eventFilter(QObject* obj, QEvent* ev) override;


### PR DESCRIPTION
In Tesseract 5.0, TessBaseAPI class became non-copyable and gImageReader's initTesseract() fails to compile.
With this patch TessBaseAPI instance is handled by smart pointer.
This patch still keeps it compatible with Tesseract 4.0.