### PR TITLE
Fix FTBFS with Tesseract 5-alpha

### DIFF
--- a/qt/src/Config.cc
+++ b/qt/src/Config.cc
@@ -31,6 +31,9 @@
 #include <enchant-provider.h>
 #define USE_STD_NAMESPACE
 #include <tesseract/baseapi.h>
+#if TESSERACT_MAJOR_VERSION >= 5
+#include <tesseract/strngs.h>
+#endif
 #include <tesseract/genericvector.h>
 #undef USE_STD_NAMESPACE
 


### PR DESCRIPTION
With Tesseract master now we have to include strngs.h explicitly to use STRING class.