### PR TITLE
Fix gettext package name

### DIFF
--- a/data/gimagereader.appdata.xml.in
+++ b/data/gimagereader.appdata.xml.in
@@ -54,7 +54,7 @@
  <url type="homepage">https://github.com/manisandro/gImageReader</url>
  <url type="translate">https://github.com/manisandro/gImageReader/blob/master/README.md</url>
  <update_contact>manisandro@gmail.com</update_contact>
- <translation type="gettext">gimagereader-@INTERFACE_TYPE@</translation>
+ <translation type="gettext">gimagereader</translation>
  <provides>
  <binary>gimagereader-@INTERFACE_TYPE@</binary>
  </provides>


### PR DESCRIPTION
The two interface uses the same gettext package name as defined here:
https://github.com/manisandro/gImageReader/blob/master/CMakeLists.txt#L48