### PR TITLE
Better HiDPI support

### DIFF
--- a/qt/src/main.cc
+++ b/qt/src/main.cc
@@ -31,7 +31,7 @@
 #include "CrashHandler.hh"
 
 int main (int argc, char* argv[]) {
-    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+	QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 	QApplication app(argc, argv);
 
 	QDir dataDir = QDir(QString("%1/../share/").arg(QApplication::applicationDirPath()));

--- a/qt/src/main.cc
+++ b/qt/src/main.cc
@@ -31,6 +31,7 @@
 #include "CrashHandler.hh"
 
 int main (int argc, char* argv[]) {
+    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 	QApplication app(argc, argv);
 
 	QDir dataDir = QDir(QString("%1/../share/").arg(QApplication::applicationDirPath()));


### PR DESCRIPTION
Qt toolbar icons are displayed too small on 4K display.
This PR makes its appearance better.

Before:
![image](https://user-images.githubusercontent.com/4285709/124749689-828b8180-df5f-11eb-9041-8fe44e3783c7.png)

After:
![image](https://user-images.githubusercontent.com/4285709/124749728-8e774380-df5f-11eb-9e5e-fb58f6ba5eb6.png)
