### PR TITLE
Apply adaptive Otsu thresholding instead of normal Otsu.

### DIFF
--- a/qt/src/Recognizer.cc
+++ b/qt/src/Recognizer.cc
@@ -204,6 +204,9 @@ std::unique_ptr<tesseract::TessBaseAPI> Recognizer::setupTesseract() {
 		tess->SetPageSegMode(MAIN->getRecognitionMenu()->getPageSegmentationMode());
 		tess->SetVariable("tessedit_char_whitelist", MAIN->getRecognitionMenu()->getCharacterWhitelist().toLocal8Bit());
 		tess->SetVariable("tessedit_char_blacklist", MAIN->getRecognitionMenu()->getCharacterBlacklist().toLocal8Bit());
+#if TESSERACT_VERSION >= TESSERACT_MAKE_VERSION(5, 0, 0)
+		tess->SetVariable("thresholding_method", "1");
+#endif
 	} else {
 		QMessageBox::critical(MAIN, _("Recognition errors occurred"), _("Failed to initialize tesseract"));
 	}


### PR DESCRIPTION
New Adaptive Otsu thresholding method is available in Tesseract 5.0.0 beta.
(See http://www.leptonica.org/binarization.html)

It makes better recognition result.