### PR TITLE
Fix HiDPI scaling for Qt5 again

### DIFF
--- a/qt/src/main.cc
+++ b/qt/src/main.cc
@@ -31,6 +31,9 @@
 #include "CrashHandler.hh"
 
 int main (int argc, char* argv[]) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+	QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
 	QApplication app(argc, argv);
 
 	QDir dataDir = QDir(QString("%1/../share/").arg(QApplication::applicationDirPath()));


### PR DESCRIPTION
I made PR to fix HiDPI scaling https://github.com/manisandro/gImageReader/pull/528 and the PR was approved.
But the fix was reverted in fee875a75e62f2dc2fb37c56633f5a0487556662.
Qt6 doesn't need Qt::AA_EnableHighDpiScaling flag but Qt5 still needs it.
I make PR again with Qt_VERSION_CHECK.