### PR TITLE
[QT] Added "output pane" icon to Qt

### DIFF
--- a/qt/data/MainWindow.ui
+++ b/qt/data/MainWindow.ui
@@ -782,8 +782,9 @@
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset theme="document-edit">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset theme="document-edit" resource="gimagereader.qrc">
+     <normaloff>:/extra-theme-icons/document-edit.png</normaloff>
+     <normalon>:/extra-theme-icons/text-plain.png</normalon>:/extra-theme-icons/document-edit.png</iconset>
    </property>
    <property name="text">
     <string>Toggle Output Pane</string>
@@ -794,7 +795,8 @@
   </action>
   <action name="actionactionBatchExport">
    <property name="icon">
-    <iconset theme="document-export"/>
+    <iconset theme="document-export">
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>actionBatchExport</string>


### PR DESCRIPTION
GTK has an icon for the output pane button, but Qt had no icon for the button at all, so I selected a similar-looking icon resource (pencil on a piece of paper) for consistency's sake. The issue is shown here, circled in red: ![gImageReader_noicon](https://user-images.githubusercontent.com/38322012/150718900-7d2a4658-b81b-4516-bde0-a6ffdc56a7b6.png)


The icon is visible in the sample screenshot in the readme, so it may have been accidentally removed at some point. 