### PR TITLE
Clean up remaining warnings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 build
+.vscode

--- a/qt/src/DisplayRenderer.cc
+++ b/qt/src/DisplayRenderer.cc
@@ -21,7 +21,10 @@
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <poppler-qt6.h>
 #else
+#pragma GCC push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <poppler-qt5.h>
+#pragma GCC pop
 #endif
 
 #include <cmath>

--- a/qt/src/SourceManager.cc
+++ b/qt/src/SourceManager.cc
@@ -38,7 +38,10 @@
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <poppler-qt6.h>
 #else
+#pragma GCC push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <poppler-qt5.h>
+#pragma GCC pop
 #endif
 
 #include "ConfigSettings.hh"


### PR DESCRIPTION
(Newer versions of poppler fix the problem, but aren't available
on Debian 11.)

(cherry picked from commit a8bd81e2703eb335e020bd5166a39eb103b7678a)