### PR TITLE
Bug fix: can't click on any item sometimes:

### DIFF
--- a/qt/src/hocr/OutputEditorHOCR.cc
+++ b/qt/src/hocr/OutputEditorHOCR.cc
@@ -598,12 +598,13 @@ void OutputEditorHOCR::showItemProperties(const QModelIndex& index, const QModel
 		QRect minBBox;
 		if(currentItem->itemClass() == "ocr_page") {
 			minBBox = currentItem->bbox();
+			m_tool->clearSelection();
 		} else {
 			for(const HOCRItem* child : currentItem->children()) {
 				minBBox = minBBox.united(child->bbox());
 			}
+			m_tool->setSelection(currentItem->bbox(), minBBox);
 		}
-		m_tool->setSelection(currentItem->bbox(), minBBox);
 	}
 }
 


### PR DESCRIPTION
For example, enable preview immediately after
recognizing a page: the whole page is selected and clicks do nothing.