### PR TITLE
Fix FTBFS in Windows with Qt6.

### DIFF
--- a/qt/src/scanner/ScannerTwain.cc
+++ b/qt/src/scanner/ScannerTwain.cc
@@ -364,7 +364,9 @@ void ScannerTwain::close() {
 }
 
 #ifdef Q_OS_WIN32
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+bool ScannerTwain::NativeEventFilter::nativeEventFilter(const QByteArray& /*eventType*/, void* message, qintptr* /*result*/)
+#elif QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 bool ScannerTwain::eventFilter(void* message)
 #else
 bool ScannerTwain::NativeEventFilter::nativeEventFilter(const QByteArray& /*eventType*/, void* message, long* /*result*/)

--- a/qt/src/scanner/ScannerTwain.hh
+++ b/qt/src/scanner/ScannerTwain.hh
@@ -95,7 +95,11 @@ private:
 	bool saveDIB(TW_MEMREF hImg, const QString& filename);
 	class NativeEventFilter : public QAbstractNativeEventFilter {
 	public:
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		bool nativeEventFilter(const QByteArray& eventType, void* message, qintptr* result) override;
+#else
 		bool nativeEventFilter(const QByteArray& eventType, void* message, long* result);
+#endif
 	};
 	NativeEventFilter m_eventFilter;
 #endif


### PR DESCRIPTION
In only Windows NativeEventFilter is used.
QAbstractNativeEventFilter interface has changed in Qt6.