### PR TITLE
Fixes for Compilation of v3.4 on Ubuntu 20.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,7 +259,7 @@ IF("${srcdir}" STREQUAL "gtk")
     ENDFOREACH()
 
 ELSEIF("${srcdir}" STREQUAL "qt")
-    QT_ADD_RESOURCES(gimagereader_RESOURCES_RCC ${gimagereader_RESOURCES})
+    QT5_ADD_RESOURCES(gimagereader_RESOURCES_RCC ${gimagereader_RESOURCES})
     SET(UIC_EXECUTABLE Qt${QT_VER}::uic)
 
     # Custom WRAP_UI which also gettext-izes the result

--- a/qt/src/ConfigSettings.cc
+++ b/qt/src/ConfigSettings.cc
@@ -41,7 +41,7 @@ TableSetting::TableSetting(const QString& key, QTableWidget* table)
 	m_table->setRowCount(0);
 	int nCols = m_table->columnCount();
 
-	for(const QString& row : str.split(';', Qt::SkipEmptyParts)) {
+	for(const QString& row : str.split(';', QString::SplitBehavior::SkipEmptyParts)) {
 		int colidx = 0;
 		QStringList cols = row.split(',');
 		if(cols.size() != nCols) {

--- a/qt/src/CrashHandler.cc
+++ b/qt/src/CrashHandler.cc
@@ -61,7 +61,7 @@ void CrashHandler::handleGdbFinished(int exitCode, QProcess::ExitStatus exitStat
 	if(exitCode != 0 || exitStatus != QProcess::NormalExit) {
 		ui.plainTextEditBacktrace->appendPlainText(_("Failed to obtain backtrace. Is GDB installed?"));
 	} else {
-		QStringList lines = ui.plainTextEditBacktrace->toPlainText().split("\n", Qt::SkipEmptyParts);
+		QStringList lines = ui.plainTextEditBacktrace->toPlainText().split("\n", QString::SplitBehavior::SkipEmptyParts);
 		ui.plainTextEditBacktrace->setPlainText(lines[0]);
 		ui.plainTextEditBacktrace->appendPlainText("\n");
 		for(int i = 1, n = lines.length(); i < n; ++i) {

--- a/qt/src/DisplayRenderer.hh
+++ b/qt/src/DisplayRenderer.hh
@@ -23,6 +23,7 @@
 #include <QByteArray>
 #include <QString>
 #include <QMutex>
+#include <memory>
 
 class DjVuDocument;
 

--- a/qt/src/FileTreeModel.cc
+++ b/qt/src/FileTreeModel.cc
@@ -73,7 +73,7 @@ QModelIndex FileTreeModel::insertFile(QString filePath, DataObject* data, const 
 		return index(row, 0, index(0, 0));
 	} else if(m_root->path.startsWith(fileDir)) {
 		// Root below new path, replace root
-		QStringList path = m_root->path.mid(fileDir.length()).split("/", Qt::SkipEmptyParts);
+		QStringList path = m_root->path.mid(fileDir.length()).split("/", QString::SplitBehavior::SkipEmptyParts);
 		beginRemoveRows(QModelIndex(), 0, 0);
 		DirNode* oldroot = m_root;
 		m_root = nullptr;
@@ -91,7 +91,7 @@ QModelIndex FileTreeModel::insertFile(QString filePath, DataObject* data, const 
 		return index(1, 0, index(0, 0));
 	} else if(fileDir.startsWith(m_root->path)) {
 		// New path below root, append to subtree
-		QStringList path = fileDir.mid(m_root->path.length()).split("/", Qt::SkipEmptyParts);
+		QStringList path = fileDir.mid(m_root->path.length()).split("/", QString::SplitBehavior::SkipEmptyParts);
 		DirNode* cur = m_root;
 		QModelIndex idx = index(0, 0);
 		for(const QString& part : path) {
@@ -116,8 +116,8 @@ QModelIndex FileTreeModel::insertFile(QString filePath, DataObject* data, const 
 		return index(row, 0, idx);
 	} else {
 		// Unrelated trees, find common ancestor
-		QStringList rootPath = m_root->path.split("/", Qt::SkipEmptyParts);
-		QStringList newPath = fileDir.split("/", Qt::SkipEmptyParts);
+		QStringList rootPath = m_root->path.split("/", QString::SplitBehavior::SkipEmptyParts);
+		QStringList newPath = fileDir.split("/", QString::SplitBehavior::SkipEmptyParts);
 		int pos = 0;
 		for(int n = qMin(rootPath.length(), newPath.length()); pos < n; ++pos) {
 			if(rootPath[pos] != newPath[pos]) {
@@ -194,7 +194,7 @@ QModelIndex FileTreeModel::findFile(const QString& filePath, bool isFile) const 
 		return QModelIndex();
 	}
 	QString relPath = fileDir.mid(m_root->path.length());
-	QStringList parts = relPath.split("/", Qt::SkipEmptyParts);
+	QStringList parts = relPath.split("/", QString::SplitBehavior::SkipEmptyParts);
 	for(const QString& part : parts) {
 		auto it = cur->dirs.find(part);
 		if(it == cur->dirs.end()) {

--- a/qt/src/RecognitionMenu.cc
+++ b/qt/src/RecognitionMenu.cc
@@ -135,7 +135,7 @@ void RecognitionMenu::rebuild() {
 		m_multilingualAction->setCheckable(true);
 		m_menuMultilanguage = new QMenu();
 		isMultilingual = curlang.prefix.contains('+');
-		QStringList sellangs = curlang.prefix.split('+', Qt::SkipEmptyParts);
+		QStringList sellangs = curlang.prefix.split('+', QString::SplitBehavior::SkipEmptyParts);
 		for(const QString& langprefix : availLanguages) {
 			if(langprefix == "osd") {
 				continue;

--- a/qt/src/Recognizer.cc
+++ b/qt/src/Recognizer.cc
@@ -144,8 +144,8 @@ QList<int> Recognizer::selectPages(bool& autodetectLayout) {
 		QString text = m_pagesDialogUi.lineEditPageRange->text();
 		if((match = validateRegEx.match(text)).hasMatch()) {
 			text.replace(QRegularExpression("\\s+"), "");
-			for(const QString& block : text.split(',', Qt::SkipEmptyParts)) {
-				QStringList ranges = block.split('-', Qt::SkipEmptyParts);
+			for(const QString& block : text.split(',', QString::SplitBehavior::SkipEmptyParts)) {
+				QStringList ranges = block.split('-', QString::SplitBehavior::SkipEmptyParts);
 				if(ranges.size() == 1) {
 					int page = ranges[0].toInt();
 					if(page > 0 && page <= nPages) {


### PR DESCRIPTION
Good afternoon,

On Ubuntu 20.04, the latest available version appears to be 3.3.1 which suffers from the fatal "`[Gtk] Fix crash in Utils::string_split_pos`" error fixed in https://github.com/manisandro/gImageReader/commit/6ead57d46fce179306067fcba484bf558b5ff913. 

This PR contains two fixes for compiling 3.4 into Ubuntu 20.04.

https://github.com/manisandro/gImageReader/commit/d070af4cb839d23dd235967be6fb497d4082765c fixes the following:

```
In file included from /home/dave/Software/gImageReader/qt/src/Displayer.cc:23:
/home/dave/Software/gImageReader/qt/src/DisplayRenderer.hh:68:14: error: ‘unique_ptr’ in namespace ‘std’ does not name a template type
   68 |         std::unique_ptr<Poppler::Document> m_document;
      |              ^~~~~~~~~~
/home/dave/Software/gImageReader/qt/src/DisplayRenderer.hh:26:1: note: ‘std::unique_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
   25 | #include <QMutex>
  +++ |+#include <memory>
   26 | 
```

and https://github.com/manisandro/gImageReader/commit/76d03023f73bc8dc2837af6008939d9d248578ed fixes the multiple occurances of:

```

     /home/dave/Software/gImageReader/qt/src/FileTreeModel.cc: In member function ‘QModelIndex FileTreeModel::insertFile(QString, DataObject*, const QString&)’:
/home/dave/Software/gImageReader/qt/src/FileTreeModel.cc:76:86: error: ‘SkipEmptyParts’ is not a member of ‘Qt’
   76 | st path = m_root->path.mid(fileDir.length()).split("/", Qt::SkipEmptyParts);
 |                                                             ^~~~~~~~~~~~~~

```
Best,
Dave
