### PR TITLE
Add custom scan modes seen in f+ imaging (Lexmark) proprietary driver

### DIFF
--- a/gtk/src/scanner/ScannerSane.cc
+++ b/gtk/src/scanner/ScannerSane.cc
@@ -266,14 +266,16 @@ void ScannerSane::doSetOptions() {
 		std::vector<std::string> color_scan_modes = {
 			SANE_VALUE_SCAN_MODE_COLOR,
 			"Color",
-			"24bit Color" /* Seen in the proprietary brother3 driver */
+			"24bit Color", /* Seen in the proprietary brother3 driver */
+			"24-bit Color" /* Seen in the proprietary f+ imaging/Lexmark driver */
 		};
 		std::vector<std::string> gray_scan_modes = {
 			SANE_VALUE_SCAN_MODE_GRAY,
 			"Gray",
 			"Grayscale",
 			SANE_I18N("Grayscale"),
-			"True Gray" /* Seen in the proprietary brother3 driver */
+			"True Gray", /* Seen in the proprietary brother3 driver */
+			"8-bit Grayscale" /* Seen in the proprietary f+ imaging/Lexmark driver */
 		};
 		std::vector<std::string> lineart_scan_modes = {
 			SANE_VALUE_SCAN_MODE_LINEART,
@@ -289,7 +291,8 @@ void ScannerSane::doSetOptions() {
 			"Gray",
 			"Grayscale",
 			SANE_I18N("Grayscale"),
-			"True Gray" /* Seen in the proprietary brother3 driver */
+			"True Gray", /* Seen in the proprietary brother3 driver */
+			"1-bit Black & White" /* Seen in the proprietary f+ imaging/Lexmark driver */
 		};
 
 		switch(m_job->params.scan_mode) {

--- a/qt/src/scanner/ScannerSane.cc
+++ b/qt/src/scanner/ScannerSane.cc
@@ -264,14 +264,16 @@ void ScannerSane::doSetOptions() {
 		QStringList color_scan_modes = {
 			SANE_VALUE_SCAN_MODE_COLOR,
 			"Color",
-			"24bit Color" /* Seen in the proprietary brother3 driver */
+			"24bit Color", /* Seen in the proprietary brother3 driver */
+			"24-bit Color" /* Seen in the proprietary f+ imaging/Lexmark driver */
 		};
 		QStringList gray_scan_modes = {
 			SANE_VALUE_SCAN_MODE_GRAY,
 			"Gray",
 			"Grayscale",
 			SANE_I18N("Grayscale"),
-			"True Gray" /* Seen in the proprietary brother3 driver */
+			"True Gray", /* Seen in the proprietary brother3 driver */
+			"8-bit Grayscale" /* Seen in the proprietary f+ imaging/Lexmark driver */
 		};
 		QStringList lineart_scan_modes = {
 			SANE_VALUE_SCAN_MODE_LINEART,
@@ -287,7 +289,8 @@ void ScannerSane::doSetOptions() {
 			"Gray",
 			"Grayscale",
 			SANE_I18N("Grayscale"),
-			"True Gray" /* Seen in the proprietary brother3 driver */
+			"True Gray", /* Seen in the proprietary brother3 driver */
+			"1-bit Black & White" /* Seen in the proprietary f+ imaging/Lexmark driver */
 		};
 
 		switch(m_job->params.scan_mode) {


### PR DESCRIPTION
An issue with distorted scan result was encountered for f+ imaging M60ade MFP.

$ sane-find-scanner -q
found USB scanner (vendor=0x043d [f+ imaging], product=0x0382 [f+ imaging M60ade]) at libusb:002:020

Debugging revealed following messages:
[...]
[New Thread 0x7fffaaffd640 (LWP 15083)]
Unable to set Color mode, please file a bug
Unable to set Color mode, please file a bug
Unable to set Gray mode, please file a bug
[Thread 0x7fffaaffd640 (LWP 15083) exited]
[Thread 0x7fffabfff640 (LWP 15081) exited]

while 'strings /usr/local/printer/unix_scan_drivers/lib/sane/libsane-mfp_nscan.so.1' showed custom constants:

[...]
1-bit Black & White
8-bit Grayscale
24-bit Color
[...]