### PR TITLE
hOCR editor: use "scan_res" instead of "res"

### DIFF
--- a/gtk/src/hocr/HOCRDocument.cc
+++ b/gtk/src/hocr/HOCRDocument.cc
@@ -1187,7 +1187,7 @@ HOCRPage::HOCRPage(const xmlpp::Element* element, int pageId, const Glib::ustrin
 		m_titleAttrs.erase(m_titleAttrs.find("pageno"));
 	}
 	m_angle = std::atof(m_titleAttrs["rot"].c_str());
-	m_resolution = std::atoi(m_titleAttrs["res"].c_str());
+	m_resolution = std::atoi(m_titleAttrs["scan_res"].c_str());
 	if(m_resolution == 0) {
 		m_resolution = 100;
 	}

--- a/gtk/src/hocr/OutputEditorHOCR.cc
+++ b/gtk/src/hocr/OutputEditorHOCR.cc
@@ -279,7 +279,7 @@ void OutputEditorHOCR::HOCRBatchProcessor::appendOutput(std::ostream& dev, tesse
 	attrs["image"] = Glib::ustring::compose("'%1'", Glib::path_get_basename(pageInfos.filename));
 	attrs["ppageno"] = Glib::ustring::compose("%1", pageInfos.page);
 	attrs["rot"] = Glib::ustring::compose("%1", pageInfos.angle);
-	attrs["res"] = Glib::ustring::compose("%1", pageInfos.resolution);
+	attrs["scan_res"] = Glib::ustring::compose("%1", pageInfos.resolution);
 	pageDiv->set_attribute("title", HOCRItem::serializeAttrGroup(attrs));
 	doc->write_to_stream(dev);
 }
@@ -556,7 +556,7 @@ void OutputEditorHOCR::addPage(const Glib::ustring& hocrText, HOCRReadSessionDat
 	attrs["image"] = Glib::ustring::compose("'%1'", data.pageInfo.filename);
 	attrs["ppageno"] = Glib::ustring::compose("%1", data.pageInfo.page);
 	attrs["rot"] = Glib::ustring::compose("%1", data.pageInfo.angle);
-	attrs["res"] = Glib::ustring::compose("%1", data.pageInfo.resolution);
+	attrs["scan_res"] = Glib::ustring::compose("%1", data.pageInfo.resolution);
 	pageDiv->set_attribute("title", HOCRItem::serializeAttrGroup(attrs));
 
 	Gtk::TreeIter index = m_document->insertPage(data.insertIndex, pageDiv, true);

--- a/qt/src/hocr/HOCRDocument.cc
+++ b/qt/src/hocr/HOCRDocument.cc
@@ -1063,7 +1063,7 @@ HOCRPage::HOCRPage(const QDomElement& element, int pageId, const QString& defaul
 		m_titleAttrs.remove("pageno");
 	}
 	m_angle = m_titleAttrs["rot"].toDouble();
-	m_resolution = m_titleAttrs.value("res", "100").toInt();
+	m_resolution = m_titleAttrs.value("scan_res", "100").toInt();
 
 	QDomElement childElement = element.firstChildElement("div");
 	while(!childElement.isNull()) {

--- a/qt/src/hocr/OutputEditorHOCR.cc
+++ b/qt/src/hocr/OutputEditorHOCR.cc
@@ -265,7 +265,7 @@ void OutputEditorHOCR::HOCRBatchProcessor::appendOutput(QIODevice* dev, tesserac
 	attrs["image"] = QString("'./%1'").arg(QFileInfo(pageInfos.filename).fileName());
 	attrs["ppageno"] = QString::number(pageInfos.page);
 	attrs["rot"] = QString::number(pageInfos.angle);
-	attrs["res"] = QString::number(pageInfos.resolution);
+	attrs["scan_res"] = QString::number(pageInfos.resolution);
 	pageDiv.setAttribute("title", HOCRItem::serializeAttrGroup(attrs));
 	dev->write(doc.toByteArray());
 }
@@ -434,7 +434,7 @@ void OutputEditorHOCR::addPage(const QString& hocrText, HOCRReadSessionData data
 	attrs["image"] = QString("'%1'").arg(data.pageInfo.filename);
 	attrs["ppageno"] = QString::number(data.pageInfo.page);
 	attrs["rot"] = QString::number(data.pageInfo.angle);
-	attrs["res"] = QString::number(data.pageInfo.resolution);
+	attrs["scan_res"] = QString::number(data.pageInfo.resolution);
 	pageDiv.setAttribute("title", HOCRItem::serializeAttrGroup(attrs));
 
 	QModelIndex index = m_document->insertPage(data.insertIndex, pageDiv, true);


### PR DESCRIPTION
cf. https://github.com/kba/hocrjs/issues/68:

> The problem is the `res` property which is not part of the hOCR spec. I think this should be [`scan_res`](https://kba.github.io/hocr-spec/1.2/#scan_res), i.e. in https://github.com/manisandro/gImageReader/blob/8a046ec7bf64e996fbc81187306334fbd11873c9/qt/src/hocr/OutputEditorHOCR.cc#L268:
> 
> ```diff
> - 	attrs["res"] = QString::number(pageInfos.resolution);
> +	attrs["scan_res"] = QString::number(pageInfos.resolution);
> ```

ht @khashashin 