### PR TITLE
hOCR editor: quote "x_font" property

### DIFF
--- a/gtk/src/hocr/OutputEditorHOCR.cc
+++ b/gtk/src/hocr/OutputEditorHOCR.cc
@@ -856,6 +856,7 @@ void OutputEditorHOCR::bboxDrawn(const Geometry::Rectangle& bbox, int action) {
 		std::map<Glib::ustring, Glib::ustring> titleAttrs;
 		titleAttrs["bbox"] = Glib::ustring::compose("%1 %2 %3 %4", bbox.x, bbox.y, bbox.x + bbox.width, bbox.y + bbox.height);
 		titleAttrs["x_font"] = propWord["title:x_font"].size() == 1 ? *propWord["title:x_font"].begin() : "sans";
+		titleAttrs["x_font"] = Glib::ustring::compose("\"%1\"", propWord["title:x_font"].size() == 1 ? *propWord["title:x_font"].begin() : "sans");
 		titleAttrs["x_fsize"] = propWord["title:x_fsize"].size() == 1 ? *propWord["title:x_fsize"].begin() : Glib::ustring::compose("%1", std::round(bbox.height * 72. / currentItem->page()->resolution()));
 		titleAttrs["x_wconf"] = "100";
 		newElement->set_attribute("title", HOCRItem::serializeAttrGroup(titleAttrs));

--- a/qt/src/hocr/OutputEditorHOCR.cc
+++ b/qt/src/hocr/OutputEditorHOCR.cc
@@ -731,8 +731,8 @@ void OutputEditorHOCR::bboxDrawn(const QRect& bbox, int action) {
 		QMap<QString, QString> titleAttrs;
 		titleAttrs["bbox"] = QString("%1 %2 %3 %4").arg(bbox.left()).arg(bbox.top()).arg(bbox.right()).arg(bbox.bottom());
 		titleAttrs["x_wconf"] = "100";
-		titleAttrs["x_font"] = propWord["title:x_font"].size() == 1 ?
-		                       *propWord["title:x_font"].begin() : QFont().family();
+		titleAttrs["x_font"] = QString("\"%1\"").arg(propWord["title:x_font"].size() == 1 ?
+		                       *propWord["title:x_font"].begin() : QFont().family());
 		titleAttrs["x_fsize"] = propWord["title:x_fsize"].size() == 1 ?
 		                        *propWord["title:x_fsize"].begin() : QString("%1").arg(qRound(bbox.height() * 72. / currentItem->page()->resolution()));
 		newElement.setAttribute("title", HOCRItem::serializeAttrGroup(titleAttrs));


### PR DESCRIPTION
cf. https://github.com/kba/hocrjs/issues/67

The `x_font` attribute must be quoted in case it contains spaces, otherwise a parser won't know where the value ends.

Untested and unsure whether the attribute-reading code needs corresponding adaption to deal with the quotes.