### PR TITLE
appdata: Fix appdata papercuts

### DIFF
--- a/data/gimagereader.appdata.xml.in
+++ b/data/gimagereader.appdata.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014 Sandro Mani <manisandro@gmail.com> -->
-<component type="desktop">
+<component type="desktop-application">
  <id>gimagereader-@INTERFACE_TYPE@.desktop</id>
  <metadata_license>CC0-1.0</metadata_license>
  <project_license>GPL-3.0+</project_license>
@@ -79,9 +79,10 @@
    <caption xml:lang="hu">gKépolvasó-@INTERFACE_TYPE@</caption>
   </screenshot>
  </screenshots>
+ <url type="homepage">https://github.com/manisandro/gImageReader</url>
  <url type="bugtracker">https://github.com/manisandro/gImageReader/issues</url>
  <url type="faq">https://github.com/manisandro/gImageReader/wiki/FAQ</url>
- <url type="homepage">https://github.com/manisandro/gImageReader</url>
+ <url type="vcs-browser">https://github.com/manisandro/gImageReader</url>
  <url type="translate">https://hosted.weblate.org/engage/gimagereader/</url>
  <update_contact>manisandro@gmail.com</update_contact>
  <translation type="gettext">gimagereader</translation>
@@ -89,7 +90,7 @@
  <binary>gimagereader-@INTERFACE_TYPE@</binary>
  </provides>
  <launchable type="desktop-id">gimagereader-@INTERFACE_TYPE@.desktop</launchable>
- <content_rating type="oars-1.0">
+ <content_rating type="oars-1.1">
  <content_attribute id="social-info">mild</content_attribute>
  </content_rating>
  <releases>


### PR DESCRIPTION
- Use desktop-application as component type
- Add vcs-browser URL to show the source code repository
- Update oars rating version to 1.1

More information: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/