### PR TITLE
fix: Failed to compile in Qt5 environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,11 @@ IF("${srcdir}" STREQUAL "gtk")
     ENDFOREACH()
 
 ELSEIF("${srcdir}" STREQUAL "qt")
-    QT_ADD_RESOURCES(gimagereader_RESOURCES_RCC ${gimagereader_RESOURCES})
+    IF("${INTERFACE_TYPE}" STREQUAL "qt5")
+        QT5_ADD_RESOURCES(gimagereader_RESOURCES_RCC ${gimagereader_RESOURCES})
+    ELSE()
+        QT_ADD_RESOURCES(gimagereader_RESOURCES_RCC ${gimagereader_RESOURCES})
+    ENDIF()
     SET(UIC_EXECUTABLE Qt${QT_VER}::uic)
 
     # Custom WRAP_UI which also gettext-izes the result

--- a/qt/src/ConfigSettings.cc
+++ b/qt/src/ConfigSettings.cc
@@ -41,7 +41,12 @@ TableSetting::TableSetting(const QString& key, QTableWidget* table)
 	m_table->setRowCount(0);
 	int nCols = m_table->columnCount();
 
-	for(const QString& row : str.split(';', Qt::SkipEmptyParts)) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+	QStringList rowList = str.split(';', QString::SkipEmptyParts);
+#else
+	QStringList rowList = str.split(';', Qt::SkipEmptyParts);
+#endif
+	for(const QString& row : rowList) {
 		int colidx = 0;
 		QStringList cols = row.split(',');
 		if(cols.size() != nCols) {

--- a/qt/src/CrashHandler.cc
+++ b/qt/src/CrashHandler.cc
@@ -61,7 +61,11 @@ void CrashHandler::handleGdbFinished(int exitCode, QProcess::ExitStatus exitStat
 	if(exitCode != 0 || exitStatus != QProcess::NormalExit) {
 		ui.plainTextEditBacktrace->appendPlainText(_("Failed to obtain backtrace. Is GDB installed?"));
 	} else {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+		QStringList lines = ui.plainTextEditBacktrace->toPlainText().split("\n", QString::SkipEmptyParts);
+#else
 		QStringList lines = ui.plainTextEditBacktrace->toPlainText().split("\n", Qt::SkipEmptyParts);
+#endif
 		ui.plainTextEditBacktrace->setPlainText(lines[0]);
 		ui.plainTextEditBacktrace->appendPlainText("\n");
 		for(int i = 1, n = lines.length(); i < n; ++i) {

--- a/qt/src/DisplayRenderer.hh
+++ b/qt/src/DisplayRenderer.hh
@@ -23,6 +23,7 @@
 #include <QByteArray>
 #include <QString>
 #include <QMutex>
+#include <memory>
 
 class DjVuDocument;
 

--- a/qt/src/FileTreeModel.cc
+++ b/qt/src/FileTreeModel.cc
@@ -73,7 +73,11 @@ QModelIndex FileTreeModel::insertFile(QString filePath, DataObject* data, const 
 		return index(row, 0, index(0, 0));
 	} else if(m_root->path.startsWith(fileDir)) {
 		// Root below new path, replace root
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+		QStringList path = m_root->path.mid(fileDir.length()).split("/", QString::SkipEmptyParts);
+#else
 		QStringList path = m_root->path.mid(fileDir.length()).split("/", Qt::SkipEmptyParts);
+#endif
 		beginRemoveRows(QModelIndex(), 0, 0);
 		DirNode* oldroot = m_root;
 		m_root = nullptr;
@@ -91,7 +95,11 @@ QModelIndex FileTreeModel::insertFile(QString filePath, DataObject* data, const 
 		return index(1, 0, index(0, 0));
 	} else if(fileDir.startsWith(m_root->path)) {
 		// New path below root, append to subtree
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+		QStringList path = fileDir.mid(m_root->path.length()).split("/", QString::SkipEmptyParts);
+#else
 		QStringList path = fileDir.mid(m_root->path.length()).split("/", Qt::SkipEmptyParts);
+#endif
 		DirNode* cur = m_root;
 		QModelIndex idx = index(0, 0);
 		for(const QString& part : path) {
@@ -116,8 +124,13 @@ QModelIndex FileTreeModel::insertFile(QString filePath, DataObject* data, const 
 		return index(row, 0, idx);
 	} else {
 		// Unrelated trees, find common ancestor
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+		QStringList rootPath = m_root->path.split("/", QString::SkipEmptyParts);
+		QStringList newPath = fileDir.split("/", QString::SkipEmptyParts);
+#else
 		QStringList rootPath = m_root->path.split("/", Qt::SkipEmptyParts);
 		QStringList newPath = fileDir.split("/", Qt::SkipEmptyParts);
+#endif
 		int pos = 0;
 		for(int n = qMin(rootPath.length(), newPath.length()); pos < n; ++pos) {
 			if(rootPath[pos] != newPath[pos]) {
@@ -194,7 +207,11 @@ QModelIndex FileTreeModel::findFile(const QString& filePath, bool isFile) const 
 		return QModelIndex();
 	}
 	QString relPath = fileDir.mid(cur->path.length());
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+	QStringList parts = relPath.split("/", QString::SkipEmptyParts);
+#else
 	QStringList parts = relPath.split("/", Qt::SkipEmptyParts);
+#endif
 	for(const QString& part : parts) {
 		auto it = cur->dirs.find(part);
 		if(it == cur->dirs.end()) {

--- a/qt/src/RecognitionMenu.cc
+++ b/qt/src/RecognitionMenu.cc
@@ -135,7 +135,11 @@ void RecognitionMenu::rebuild() {
 		m_multilingualAction->setCheckable(true);
 		m_menuMultilanguage = new QMenu();
 		isMultilingual = curlang.prefix.contains('+');
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+		QStringList sellangs = curlang.prefix.split('+', QString::SkipEmptyParts);
+#else
 		QStringList sellangs = curlang.prefix.split('+', Qt::SkipEmptyParts);
+#endif
 		for(const QString& langprefix : availLanguages) {
 			if(langprefix == "osd") {
 				continue;

--- a/qt/src/Recognizer.cc
+++ b/qt/src/Recognizer.cc
@@ -144,8 +144,17 @@ QList<int> Recognizer::selectPages(bool& autodetectLayout) {
 		QString text = m_pagesDialogUi.lineEditPageRange->text();
 		if((match = validateRegEx.match(text)).hasMatch()) {
 			text.replace(QRegularExpression("\\s+"), "");
-			for(const QString& block : text.split(',', Qt::SkipEmptyParts)) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+			QStringList blockList = text.split(',', QString::SkipEmptyParts);
+#else
+			QStringList blockList = text.split(',', Qt::SkipEmptyParts);
+#endif
+			for(const QString& block : blockList) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+				QStringList ranges = block.split('-', QString::SkipEmptyParts);
+#else
 				QStringList ranges = block.split('-', Qt::SkipEmptyParts);
+#endif
 				if(ranges.size() == 1) {
 					int page = ranges[0].toInt();
 					if(page > 0 && page <= nPages) {


### PR DESCRIPTION
Refactored the resource handling in CMakeLists.txt to support both Qt5 and Qt6 versions

Additionally, updated string splitting logic across multiple files to ensure compatibility with different Qt versions.

![截图_选择区域_20241119094706](https://github.com/user-attachments/assets/41aecb92-5ea8-41e3-8af8-a8b03cc1b6b3)
![截图_选择区域_20241119095548](https://github.com/user-attachments/assets/1fefd0fd-47ef-4cff-b6a1-dc2d1e3a4c8b)
