### PR TITLE
fix: Fix memory leaks in Displayer and RecognitionMenu

### DIFF
--- a/qt/src/Displayer.cc
+++ b/qt/src/Displayer.cc
@@ -126,6 +126,7 @@ bool Displayer::setSources(QList<Source*> sources) {
 	m_renderTimer.stop();
 	if(m_imageItem) {
 		m_scene->removeItem(m_imageItem);
+		delete m_imageItem;
 	}
 	m_currentSource = nullptr;
 	qDeleteAll(m_sourceRenderers);

--- a/qt/src/RecognitionMenu.cc
+++ b/qt/src/RecognitionMenu.cc
@@ -170,7 +170,7 @@ void RecognitionMenu::rebuild() {
 
 	// Add PSM items
 	addSeparator();
-	QMenu* psmMenu = new QMenu();
+	QMenu* psmMenu = new QMenu(this);
 	int activePsm = ConfigSettings::get<VarSetting<int>>("psm")->getValue();
 
 	struct PsmEntry {


### PR DESCRIPTION
Fix two memory management issues:
- Add missing deletion of m_imageItem in Displayer::setSources
- Set proper parent for PSM menu to ensure proper cleanup

These changes prevent memory leaks and ensure proper resource cleanup when the application exits or when components are destroyed.