### PR TITLE
chore: remove some variable that never used.

### DIFF
--- a/qt/src/FileTreeModel.cc
+++ b/qt/src/FileTreeModel.cc
@@ -145,7 +145,7 @@ QModelIndex FileTreeModel::insertFile(QString filePath, DataObject* data, const 
 		path = newPath.mid(pos);
 		QModelIndex idx = index(0, 0);
 		for(int i = 0, n = path.length(); i < n; ++i) {
-			int pos = cur->dirs.insIndex(path[i]);
+            pos = cur->dirs.insIndex(path[i]);
 			cur = cur->dirs.add(new DirNode(path[i], cur->path + "/" + path[i], cur), pos);
 			idx = index(pos, 0, idx);
 		}
@@ -164,11 +164,9 @@ QModelIndex FileTreeModel::findFile(const QString& filePath, bool isFile) const 
 #ifdef Q_OS_WIN32
 	QString prefix = "/";
 	QString fileDir = "/" + finfo.absolutePath().replace("\\", "/");
-	QString tempPath = "/" + QDir::tempPath();
 #else
 	QString prefix = "";
 	QString fileDir = finfo.absolutePath();
-	QString tempPath = QDir::tempPath();
 #endif
 	QString fileName = finfo.fileName();
 

--- a/qt/src/FileTreeModel.hh
+++ b/qt/src/FileTreeModel.hh
@@ -47,8 +47,6 @@ public:
 	int rowCount(const QModelIndex& parent = QModelIndex()) const override;
 	int columnCount(const QModelIndex& parent = QModelIndex()) const override;
 
-	static constexpr int OutputFileRole = Qt::UserRole;
-
 private:
 	template<class T>
 	class NodeList : public std::vector<T> {


### PR DESCRIPTION
1. class member 'FileTreeModel::OutputFileRole' is never used.
2. Local variable 'pos' shadows outer varibale.
3. Variable 'tempPath' is assigned a value that is never used.