### PR TITLE
chore: some function argument name different.

### DIFF
--- a/qt/src/hocr/HOCRDocument.cc
+++ b/qt/src/hocr/HOCRDocument.cc
@@ -125,7 +125,7 @@ QModelIndex HOCRDocument::indexAtItem(const HOCRItem* item) const {
 		parent = parent->parent();
 	}
 	QModelIndex idx;
-	for (HOCRItem* parent : parents) {
+	for (const HOCRItem* parent : parents) {
 		idx = index(parent->index(), 0, idx);
 	}
 	return index(item->index(), 0, idx);
@@ -942,7 +942,7 @@ void HOCRItem::getPropagatableAttributes(QMap<QString, QMap<QString, QSet<QStrin
 	QString childClass = m_childItems.isEmpty() ? "" : m_childItems.front()->itemClass();
 	auto it = s_propagatableAttributes.find(childClass);
 	if (it != s_propagatableAttributes.end()) {
-		for (HOCRItem* child : m_childItems) {
+		for (const HOCRItem* child : m_childItems) {
 			QMap<QString, QString> attrs = child->getAttributes(it.value());
 			for (auto attrIt = attrs.begin(), attrItEnd = attrs.end(); attrIt != attrItEnd; ++attrIt) {
 				occurrences[childClass][attrIt.key()].insert(attrIt.value());
@@ -950,7 +950,7 @@ void HOCRItem::getPropagatableAttributes(QMap<QString, QMap<QString, QSet<QStrin
 		}
 	}
 	if (childClass != "ocrx_word") {
-		for (HOCRItem* child : m_childItems) {
+		for (const HOCRItem* child : m_childItems) {
 			child->getPropagatableAttributes(occurrences);
 		}
 	}

--- a/qt/src/hocr/HOCRDocument.hh
+++ b/qt/src/hocr/HOCRDocument.hh
@@ -62,8 +62,8 @@ public:
 	}
 	QModelIndex indexAtItem(const HOCRItem* item) const;
 	bool editItemAttribute(const QModelIndex& index, const QString& name, const QString& value, const QString& attrItemClass = QString());
-	QModelIndex moveItem(const QModelIndex& itemIndex, const QModelIndex& newParent, int row);
-	QModelIndex swapItems(const QModelIndex& parent, int startRow, int endRow);
+	QModelIndex moveItem(const QModelIndex& itemIndex, const QModelIndex& newParent, int newRow);
+	QModelIndex swapItems(const QModelIndex& parent, int firstRow, int secondRow);
 	QModelIndex mergeItems(const QModelIndex& parent, int startRow, int endRow);
 	QModelIndex splitItem(const QModelIndex& itemIndex, int startRow, int endRow);
 	QModelIndex splitItemText(const QModelIndex& itemIndex, int pos);
@@ -208,7 +208,7 @@ protected:
 
 	// All mutations must be done through methods of HOCRDocument
 	void addChild(HOCRItem* child);
-	void insertChild(HOCRItem* child, int index);
+	void insertChild(HOCRItem* child, int i);
 	void removeChild(HOCRItem* child);
 	void takeChild(HOCRItem* child);
 	QVector<HOCRItem*> takeChildren();


### PR DESCRIPTION
1. Variable 'child' can be declared as pointer to const.
2. Function 'moveItem' argument 3 names different: declaration 'row' definition 'newRow'.
3. Function 'swapItems' argument 2 names different: declaration 'startRow' definition 'firstRow'.
4. Function 'insertChild' argument 2 names different: declaration 'index' definition 'i'.